### PR TITLE
Fix missing uint replacements

### DIFF
--- a/libnet/include/libnet/libnet-functions.h
+++ b/libnet/include/libnet/libnet-functions.h
@@ -791,8 +791,8 @@ const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
  * @return protocol tag value on success, -1 on error
  */
 libnet_ptag_t
-libnet_build_icmpv6_unreach(u_int8_t type, u_int8_t code, u_int16_t sum,
-u_int8_t *payload, u_int32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
+libnet_build_icmpv6_unreach(uint8_t type, uint8_t code, uint16_t sum,
+uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
 
 /**
  * Builds an RFC 1112 Internet Group Memebership Protocol (IGMP) header.

--- a/libnet/src/libnet_build_icmp.c
+++ b/libnet/src/libnet_build_icmp.c
@@ -397,10 +397,10 @@ bad:
 
 
 libnet_ptag_t
-libnet_build_icmpv6_unreach(u_int8_t type, u_int8_t code, u_int16_t sum,
-u_int8_t *payload, u_int32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
+libnet_build_icmpv6_unreach(uint8_t type, uint8_t code, uint16_t sum,
+uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    u_int32_t n, h;
+    uint32_t n, h;
     libnet_pblock_t *p;
     struct libnet_icmpv6_hdr icmp_hdr;
 

--- a/libnet/src/libnet_checksum.c
+++ b/libnet/src/libnet_checksum.c
@@ -345,10 +345,10 @@ libnet_inet_checksum(libnet_t *l, uint8_t *iphdr, int protocol, int h_len, const
             icmph_p->icmp_sum = 0;
             if (is_ipv6)
             {
-                sum = libnet_in_cksum((u_int16_t *)&ip6h_p->ip_src, 32);
+                sum = libnet_in_cksum((uint16_t *)&ip6h_p->ip_src, 32);
                 sum += ntohs(IPPROTO_ICMP6 + h_len);
             }
-            sum += libnet_in_cksum((u_int16_t *)icmph_p, h_len);
+            sum += libnet_in_cksum((uint16_t *)icmph_p, h_len);
             icmph_p->icmp_sum = LIBNET_CKSUM_CARRY(sum);
             break;
         }


### PR DESCRIPTION
The current 1.1.5 is missing some replacements of u_int to uint. The diff fixes the missing replacements and allows a clean build on Solaris.
