### PR TITLE
Fixes a bug that incorrectly converts the addr, mask, and next_hop fields

### DIFF
--- a/libnet/src/libnet_build_rip.c
+++ b/libnet/src/libnet_build_rip.c
@@ -73,9 +73,9 @@ libnet_ptag_t ptag)
     rip_hdr.rip_rd       = htons(rd);
     rip_hdr.rip_af       = htons(af);
     rip_hdr.rip_rt       = htons(rt);
-    rip_hdr.rip_addr     = htonl(addr);
-    rip_hdr.rip_mask     = htonl(mask);
-    rip_hdr.rip_next_hop = htonl(next_hop);
+    rip_hdr.rip_addr     = addr;
+    rip_hdr.rip_mask     = mask;
+    rip_hdr.rip_next_hop = next_hop;
     rip_hdr.rip_metric   = htonl(metric);
 
     n = libnet_pblock_append(l, p, (uint8_t *)&rip_hdr, LIBNET_RIP_H);


### PR DESCRIPTION
Fixes a bug that incorrectly converts the addr, mask, and next_hop fields back to host byte order. Users will usually call libnet_name2addr4 to fill these fields. The libnet_name2addr4 function already provides a network byte-ordered value. Calling htonl these is inconsistent with libnet_build_ip(), which assumes the addresses are in network order. 
