### PR TITLE
Update libnet_dll.c

### DIFF
--- a/libnet/src/libnet_dll.c
+++ b/libnet/src/libnet_dll.c
@@ -29,7 +29,7 @@
  *
  */
 
-#include "common"
+#include "common.h"
 #include "packet32.h"
 
 BOOL WINAPI DllMain(HINSTANCE hinst, ULONG fdwReason, LPVOID lpReserved)


### PR DESCRIPTION
Missing ".h" breaks VS2012 builds
