### PR TITLE
Fix #34 correct checksum caculation when IPv6 extension headers being used

### DIFF
--- a/libnet/src/common.h
+++ b/libnet/src/common.h
@@ -43,6 +43,9 @@
  * included.
  */
 #include <netinet/in.h>
+#ifndef IPPROTO_MH		
+#define IPPROTO_MH		135	/* IPv6 mobility header		*/
+#endif
 
 /* TODO - should ../include/gnuc.h be included here? */
 

--- a/libnet/src/libnet_checksum.c
+++ b/libnet/src/libnet_checksum.c
@@ -201,11 +201,39 @@ libnet_inet_checksum(libnet_t *l, uint8_t *iphdr, int protocol, int h_len, const
         ip6h_p = (struct libnet_ipv6_hdr *)iph_p;
         iph_p = NULL;
         ip_hl   = 40;
+        uint8_t ip_nh = ip6h_p->ip_nh;
+
         if((uint8_t*)(ip6h_p+1) > end)
         {
             snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                     "%s(): ipv6 hdr not inside packet", __func__);
             return -1;
+        }
+
+        while (ip_nh != protocol && (uint8_t*)ip6h_p + ip_hl + 1 < end)
+        { /* next header is not the upper layer protocol */
+           switch (ip_nh)
+           {
+              case IPPROTO_DSTOPTS:
+              case IPPROTO_HOPOPTS:
+              case IPPROTO_ROUTING:
+              case IPPROTO_FRAGMENT:
+              case IPPROTO_AH:
+              case IPPROTO_ESP:
+              case IPPROTO_MH:
+                 /*
+                  * count option headers to the header length for 
+                  * checksum processing
+                  */
+                 ip_nh = *((uint8_t*)ip6h_p+ip_hl); /* next next header */
+                 ip_hl += (*((uint8_t*)ip6h_p+ip_hl+1)+1)*8; /* ext header length */
+                 break;
+              default:
+                 snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
+                     "%s(): unsupported extension header (%d)", __func__, ip_nh);
+                 return -1;
+           }
+
         }
     }
     else


### PR DESCRIPTION
This pull request addresses the issue reported in #34.
The reason is that for checksum calculation in IPv6, the upper layer protocol is assumed to follow directly after the IP header. But when extension headers are used, the IPv6 header becomes longer and the upper layer protocol is shifted back. Hence the upper layer protocol checksum calculation has also to be shifted accordingly.
