### PR TITLE
Fix build error in Mac OS X

### DIFF
--- a/libnet/src/libnet_link_bpf.c
+++ b/libnet/src/libnet_link_bpf.c
@@ -315,9 +315,16 @@ libnet_get_hwaddr(libnet_t *l)
         {
             sdl = (struct sockaddr_dl *)(ifm + 1);
             if (sdl->sdl_type != IFT_ETHER
+#ifdef IFT_FASTETHER
                 && sdl->sdl_type != IFT_FASTETHER
+#endif
+#ifdef IFT_FASTETHERFX
                 && sdl->sdl_type != IFT_FASTETHERFX
+#endif
+#ifdef IFT_GIGABITETHERNET
                 && sdl->sdl_type != IFT_GIGABITETHERNET
+#endif
+
                 && sdl->sdl_type != IFT_L2VLAN)
                 continue;
             if (strncmp(&sdl->sdl_data[0], l->device, sdl->sdl_nlen) == 0)


### PR DESCRIPTION
The IFT_FASTETHER, IFT_FASTETHERFX, IFT_GIGABITETHERNET constants are not defined in Mac OS X Mountain Lion. Only IFT_ETHER and IFT_L2VLAN are. This patch checks for the existence of these definitions.
