### PR TITLE
Check for doxygen before building

### DIFF
--- a/Build
+++ b/Build
@@ -2,7 +2,10 @@
 
 set -e
 
-make -C doc doc
+if ! make -C doc doc; then
+  echo "You must have doxygen installed."
+  exit -1
+fi
 make
 make dist && mv libnet-1*.tar.gz ..
 


### PR DESCRIPTION
Make does not complete without error if doxygen is not installed properly or the document generation is not successful. This patch fixes this issue.
