### PR TITLE
Update libnet_resolve.c

### DIFF
--- a/libnet/src/libnet_resolve.c
+++ b/libnet/src/libnet_resolve.c
@@ -409,14 +409,13 @@ libnet_get_ipaddr4(libnet_t *l)
 uint32_t
 libnet_get_ipaddr4(libnet_t *l)
 {
-    long npflen = 0;
+    long npflen = 1;
     struct sockaddr_in sin;
     struct npf_if_addr ipbuff;
 
     memset(&sin,0,sizeof(sin));
     memset(&ipbuff,0,sizeof(ipbuff));
 
-    npflen = sizeof(ipbuff);
     if (PacketGetNetInfoEx(l->device, &ipbuff, &npflen))
     {
         sin = *(struct sockaddr_in *)&ipbuff.IPAddress;


### PR DESCRIPTION
in libnet_get_ipaddr4 (**WIN32** defined) the PacketGetNetInfoEx(l->device, &ipbuff, &npflen) takes a pointer to the count of buffers in the last parameter, not to the size of one buffer. This causes buffer overruns (tested in MSVC 2013 ultimate), changing the npflen to 1 solves this issue.
