### PR TITLE
OpenBSD Behavior with Multiple DOWN Interfaces + snprintf Downstream Patch

### DIFF
--- a/libnet/configure.ac
+++ b/libnet/configure.ac
@@ -284,10 +284,8 @@ dnl
 *cygwin*)
      AC_DEFINE(LIBNET_BSDISH_OS, 1,
          [Define if our build OS supports the BSD APIs])
-     AC_DEFINE(NO_SNPRINTF, 1,
-         [Define if snprintf() is unavailable on our system.])
-     LIBNET_CONFIG_DEFINES="-DLIBNET_BSDISH_OS -DNO_SNPRINTF"
-     CFLAGS="$CFLAGS -mno-cygwin -O0 -fnative-struct -DNO_SNPRINTF -I/usr/include/pcap"
+     LIBNET_CONFIG_DEFINES="-DLIBNET_BSDISH_OS"
+     CFLAGS="$CFLAGS -mno-cygwin -O0 -fnative-struct -I/usr/include/pcap"
      AC_CHECK_LIB(packet, PacketSetMode, ,AC_MSG_ERROR(packet lib not found.))
      AC_CHECK_LIB(wpcap, pcap_setmode, ,AC_MSG_ERROR(pcap lib not found.))
      LIBS="$LIBS -lws2_32"

--- a/libnet/include/libnet/libnet-macros.h
+++ b/libnet/include/libnet/libnet-macros.h
@@ -36,11 +36,6 @@
  * @brief libnet macros and symbolic constants
  */
 
-/* for systems without snprintf */
-#if defined(NO_SNPRINTF)
-#define snprintf(buf, len, args...) sprintf(buf, ##args)
-#endif
-
 
 /**
  * Used for libnet's name resolution functions, specifies that no DNS lookups

--- a/libnet/src/libnet_build_gre.c
+++ b/libnet/src/libnet_build_gre.c
@@ -325,7 +325,8 @@ libnet_ptag_t ptag)
 
     if ((routing && !length) || (!routing && length))
     {
-        sprintf(l->err_buf, "%s(): routing inconsistency", __func__);
+        snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
+                 "%s(): routing inconsistency", __func__);
         goto bad;
     }
 

--- a/libnet/src/libnet_link_bpf.c
+++ b/libnet/src/libnet_link_bpf.c
@@ -30,7 +30,9 @@
 #include "common.h"
 
 #include <sys/param.h>  /* optionally get BSD define */
+#ifndef __OpenBSD__
 #include <sys/timeb.h>
+#endif
 #include <sys/file.h>
 #include <sys/ioctl.h>
 

--- a/libnet/src/libnet_link_bpf.c
+++ b/libnet/src/libnet_link_bpf.c
@@ -61,9 +61,9 @@ libnet_bpf_open(char *err_buf)
     /*
      *  Go through all the minors and find one that isn't in use.
      */
-    for (i = 0;;i++)
+    for (i = 0; i < 1000; i++)
     {
-        sprintf(device, "/dev/bpf%d", i);
+        snprintf(device, sizeof(device), "/dev/bpf%d", i);
 
         fd = open(device, O_RDWR);
         if (fd == -1 && errno == EBUSY)

--- a/libnet/src/libnet_link_nit.c
+++ b/libnet/src/libnet_link_nit.c
@@ -52,7 +52,8 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
     l->fd = socket(AF_NIT, SOCK_RAW, NITPROTO_RAW);
     if (l->fd < 0)
     {
-        sprintf(ebuf, "socket: %s", strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "socket: %s", strerror(errno));
         goto bad;
     }
     snit.snit_family = AF_NIT;
@@ -61,7 +62,8 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
 
     if (bind(l->fd, (struct sockaddr *)&snit, sizeof(snit)))
     {
-        sprintf(ebuf, "bind: %s: %s", snit.snit_ifname, strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "bind: %s: %s", snit.snit_ifname, strerror(errno));
         goto bad;
     }
 

--- a/libnet/src/libnet_link_pf.c
+++ b/libnet/src/libnet_link_pf.c
@@ -49,14 +49,16 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
     l = (struct libnet_link_int *)malloc(sizeof(*l));
     if (l == NULL)
     {
-        sprintf(ebuf, "libnet_open_link_int: %s", strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "libnet_open_link_int: %s", strerror(errno));
         return (0);
     }
     memset(l, 0, sizeof(*l));
     l->fd = pfopen(device, O_RDWR);
     if (l->fd < 0)
     {
-        sprintf(ebuf, "pf open: %s: %s\n\your system may not be properly configured; see \"man packetfilter(4)\"",
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "pf open: %s: %s\n\your system may not be properly configured; see \"man packetfilter(4)\"",
             device, strerror(errno));
         goto bad;
     }
@@ -64,7 +66,8 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
     enmode = ENTSTAMP|ENBATCH|ENNONEXCL;
     if (ioctl(l->fd, EIOCMBIS, (caddr_t)&enmode) < 0)
     {
-        sprintf(ebuf, "EIOCMBIS: %s", strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "EIOCMBIS: %s", strerror(errno));
         goto bad;
     }
 #ifdef	ENCOPYALL
@@ -75,7 +78,8 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
 	/* set the backlog */
     if (ioctl(l->fd, EIOCSETW, (caddr_t)&backlog) < 0)
     {
-        sprintf(ebuf, "EIOCSETW: %s", strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "EIOCSETW: %s", strerror(errno));
         goto bad;
     }
     /*
@@ -83,7 +87,8 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
      */
     if (ioctl(l->fd, EIOCDEVP, (caddr_t)&devparams) < 0)
     {
-        sprintf(ebuf, "EIOCDEVP: %s", strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "EIOCDEVP: %s", strerror(errno));
         goto bad;
     }
 
@@ -117,7 +122,8 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
     Filter.enf_FilterLen = 0;	/* means "always true" */
     if (ioctl(l->fd, EIOCSETF, (caddr_t)&Filter) < 0)
     {
-        sprintf(ebuf, "EIOCSETF: %s", strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "EIOCSETF: %s", strerror(errno));
         goto bad;
     }
 

--- a/libnet/src/libnet_link_pf.c
+++ b/libnet/src/libnet_link_pf.c
@@ -58,7 +58,7 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
     if (l->fd < 0)
     {
         snprintf(ebuf, LIBNET_ERRBUF_SIZE,
-                 "pf open: %s: %s\n\your system may not be properly configured; see \"man packetfilter(4)\"",
+                 "pf open: %s: %s\nyour system may not be properly configured; see \"man packetfilter(4)\"",
             device, strerror(errno));
         goto bad;
     }

--- a/libnet/src/libnet_link_snit.c
+++ b/libnet/src/libnet_link_snit.c
@@ -58,7 +58,8 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
     l->fd  = open(dev, O_RDWR);
     if (l->fd < 0)
     {
-        sprintf(ebuf, "%s: %s", dev, strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "%s: %s", dev, strerror(errno));
         goto bad;
     }
 
@@ -67,12 +68,14 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
      */
     if (ioctl(l->fd, I_SRDOPT, (int8_t *)RMSGD) < 0)
     {
-        sprintf(ebuf, "I_SRDOPT: %s", strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "I_SRDOPT: %s", strerror(errno));
         goto bad;
     }
     if (ioctl(l->fd, I_PUSH, "nbuf") < 0)
     {
-        sprintf(ebuf, "push nbuf: %s", strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "push nbuf: %s", strerror(errno));
         goto bad;
     }
     /*
@@ -85,7 +88,8 @@ libnet_open_link_interface(int8_t *device, int8_t *ebuf)
     si.ic_dp = (int8_t *)&ifr;
     if (ioctl(l->fd, I_STR, (int8_t *)&si) < 0)
     {
-        sprintf(ebuf, "NIOCBIND: %s: %s", ifr.ifr_name, strerror(errno));
+        snprintf(ebuf, LIBNET_ERRBUF_SIZE,
+                 "NIOCBIND: %s: %s", ifr.ifr_name, strerror(errno));
         goto bad;
     }
 

--- a/libnet/src/libnet_link_snoop.c
+++ b/libnet/src/libnet_link_snoop.c
@@ -69,7 +69,8 @@ libnet_open_link(libnet_t *l)
     l->fd = socket(PF_RAW, SOCK_RAW, RAWPROTO_DRAIN);
 
     if (l->fd < 0) {
-        sprintf(l->err_buf, "drain socket: %s", strerror(errno));
+        snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
+                 "drain socket: %s", strerror(errno));
         goto bad;
     }
 
@@ -79,7 +80,8 @@ libnet_open_link(libnet_t *l)
     sr.sr_ifname[sizeof(sr.sr_ifname) - 1] = '\0';
 
     if (bind(l->fd, (struct sockaddr *)&sr, sizeof(sr))) {
-        sprintf(l->err_buf, "drain bind: %s", strerror(errno));
+        snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
+                 "drain bind: %s", strerror(errno));
         goto bad;
     }
 
@@ -107,7 +109,8 @@ libnet_open_link(libnet_t *l)
     } else if (strncmp("lo", l->device, 2) == 0) {
         l->link_type = DLT_NULL;
     } else {
-        sprintf(l->err_buf, "drain: unknown physical layer type");
+        snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
+                 "drain: unknown physical layer type");
         goto bad;
     }
 

--- a/libnet/win32/config.h
+++ b/libnet/win32/config.h
@@ -21,7 +21,6 @@
 #undef __FAVOR_BSD
 #undef LIBNET_BIG_ENDIAN
 #define LIBNET_LIL_ENDIAN 1
-#undef NO_SNPRINTF
 
 
 /*


### PR DESCRIPTION
* Fixing Openbsd Behavior with Multiple DOWN Interface 
move to cleaner libc getiffaddrs :
  * 2002 in glibc
  * uClibc available  https://github.com/hwoarang/uClibc/blob/master-metag/libc/inet/ifaddrs.c 
  * Since 'OpenBSD 2.7'
* Using snprintf as patched downstream in 1.0
* Remove the timeb include that block builds