### PR TITLE
Fix #1: Add mac to libnet_t for use with libnet_get_hwaddr()

### DIFF
--- a/include/libnet/libnet-structures.h
+++ b/include/libnet/libnet-structures.h
@@ -231,6 +231,8 @@ struct libnet_context
 
     char err_buf[LIBNET_ERRBUF_SIZE];   /* error buffer */
     uint32_t total_size;               /* total size */
+
+    struct libnet_ether_addr link_addr; /* Link HW addr */
 };
 typedef struct libnet_context libnet_t;
 

--- a/src/libnet_link_bpf.c
+++ b/src/libnet_link_bpf.c
@@ -259,8 +259,6 @@ libnet_get_hwaddr(libnet_t *l)
     int8_t *buf, *next, *end;
     struct if_msghdr *ifm;
     struct sockaddr_dl *sdl;
-    /* This implementation is not-reentrant. */
-    static struct libnet_ether_addr ea;
 
     mib[0] = CTL_NET;
     mib[1] = AF_ROUTE;
@@ -330,7 +328,7 @@ libnet_get_hwaddr(libnet_t *l)
             if (sdl->sdl_nlen == strlen(l->device)
                 && strncmp(&sdl->sdl_data[0], l->device, sdl->sdl_nlen) == 0)
             {
-                memcpy(ea.ether_addr_octet, LLADDR(sdl), ETHER_ADDR_LEN);
+                memcpy(l->link_addr.ether_addr_octet, LLADDR(sdl), ETHER_ADDR_LEN);
                 break;
             }
         }
@@ -342,7 +340,7 @@ libnet_get_hwaddr(libnet_t *l)
                  __func__, l->device);
         return NULL;
     }
-    return (&ea);
+    return (&l->link_addr);
 }
 
 

--- a/src/libnet_link_win32.c
+++ b/src/libnet_link_win32.c
@@ -173,8 +173,7 @@ libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
 struct libnet_ether_addr *
 libnet_get_hwaddr(libnet_t *l)
 {
-    /* This implementation is not-reentrant. */
-    static struct libnet_ether_addr *mac;
+    struct libnet_ether_addr *mac = &l->link_addr;
     
     ULONG IoCtlBufferLength = (sizeof(PACKET_OID_DATA) + sizeof(ULONG) - 1);
 	PPACKET_OID_DATA OidData;
@@ -195,14 +194,6 @@ libnet_get_hwaddr(libnet_t *l)
             return (NULL);
         }
     }
-
-    mac = (struct libnet_ether_addr *)calloc(1,sizeof(struct libnet_ether_addr));
-	if (mac == NULL)
-	{
-		snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
-                    "%s(): calloc error", __func__);
-		return (NULL);
-	}
 
     OidData = (struct _PACKET_OID_DATA *) malloc(IoCtlBufferLength);
 	


### PR DESCRIPTION
This patch adds a `struct libnet_ether_addr` member to libnet_t which
libnet_get_hwaddr() can safely return for each call.

Also, some of the backends returned a malloc()'ed pointer instead of a
pointer to a static stack variable.  That has been purged but should
probably be mentioned in the ChangeLog.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>