### PR TITLE
Cannot use the `-m` flag in first-time builds

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,4 +6,4 @@
 # Regular users building from released tarballs can use the shipped
 # configure script, that generates Makefile's from Makefile.in's
 
-autoreconf -W portability -vifm $*
+autoreconf -W portability -vif $*


### PR DESCRIPTION
Running autogen.sh failed with:

        autoreconf: no config.status: cannot re-make

The `-m` flag does not appear necessary, and removing it allows
autotools to generate the configure script.