### PR TITLE
Fix C89 syntax error, and document C89 being the style

### DIFF
--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -8,6 +8,7 @@ Maintenance
 * Reference issues from GitHub pull requests to alert issue subscribers
 * Use version in `configure.ac` for -betaN/-rcN and GA releases
 * Bump ABI version in `src/Makefile.am` just before release! (see below)
+* Coding style is C89 keeping consistent brace and indentation style.
 
 
 Release Checklist

--- a/include/libnet.h.in
+++ b/include/libnet.h.in
@@ -49,7 +49,7 @@ extern "C" {
  * TODO move the stuff we ALWAYS need out of the DOXYGEN ifndef block
  * and minimize their redundancies (see doc/TODO)
  */
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // mess
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>


### PR DESCRIPTION
I say C89 because variables are always declared at top of a scope, so merely documenting the status quo.