### PR TITLE
Make man-page generation reproducible

### DIFF
--- a/doc/fixmanpages.in
+++ b/doc/fixmanpages.in
@@ -32,10 +32,10 @@ test -d $MANDIR/man3 || die "Could not locate $MANDIR/man3 directory."
 find $MANDIR/man3/ -name "libnet.h.3" -exec sh -c 'rm -f "$1"' _ {} \;
 
 # Let's create libnet.3 before dealing with the rest.
-# BTW: We're using this hideous date format because Doxygen generated man
+# BTW: We're using this date format because Doxygen generated man
 # pages have them set like this and our date format shouldn't look different.
 
-pod2man -d "$(date +%a\ %b\ %d\ %C%y)" -n LIBNET -c "libnet Programmers Guide" -s 3 -r "@PACKAGE_NAME@-@PACKAGE_VERSION@" @top_srcdir@/doc/libnet.Pod man/man3/libnet.3 || die "Could not create libnet.3 in $MANDIR/man/man3."
+pod2man -d "$(LC_ALL=C date -u -r @top_srcdir@/doc/libnet.Pod +%d\ %B\ %Y)" -n LIBNET -c "libnet Programmers Guide" -s 3 -r "@PACKAGE_NAME@-@PACKAGE_VERSION@" @top_srcdir@/doc/libnet.Pod man/man3/libnet.3 || die "Could not create libnet.3 in $MANDIR/man/man3."
 
 # pod2html --title="libnet Programmers Guide" --noindex --infile=libnet.Pod --outfile=libnet.html
 


### PR DESCRIPTION
Make man-page generation reproducible

For this we behave similar to `pod2man` and use the input file mtime.

Also adapt date format to what doxygen-1.8.20 produces
to make the comment above true again.

`LC_ALL=C` is used so that %B is independent of language.

Also use UTC to be independent of timezone.

a simpler alternative approach would be to drop `-d` and accept pod2man's
ISO-8601 date format (e.g. 2019-10-15) 


This patch was done while working on [reproducible builds](https://reproducible-builds.org/) for [openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).