### PR TITLE
Fix segmentation fault in libnet_ifaddrlist

### DIFF
--- a/src/libnet_if_addr.c
+++ b/src/libnet_if_addr.c
@@ -116,7 +116,7 @@ libnet_ifaddrlist(register struct libnet_ifaddr_list **ipaddrp, char *dev, regis
     }
     for (ifa = ifap; ifa; ifa = ifa->ifa_next)
     {
-        if (ifa->ifa_flags & IFF_LOOPBACK)
+        if (ifa->ifa_flags & IFF_LOOPBACK || ifa->ifa_addr == NULL)
             continue;
 
         if (ifa->ifa_addr->sa_family == AF_INET )


### PR DESCRIPTION
According to getifaddrs man page, ifa_addr can be NULL. Skip
such interfaces to avoid NULL dereference.