### PR TITLE
Fix a few gcc -fanalyzer warnings

### DIFF
--- a/src/libnet_cq.c
+++ b/src/libnet_cq.c
@@ -128,7 +128,7 @@ libnet_cq_add(libnet_t *l, char *label)
     }
 
     new = (libnet_cq_t *)malloc(sizeof (libnet_cq_t));
-    if (l_cq == NULL)
+    if (new == NULL)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                 "%s(): can't malloc new context queue: %s",

--- a/src/libnet_pblock.c
+++ b/src/libnet_pblock.c
@@ -489,7 +489,6 @@ libnet_pblock_coalesce(libnet_t *l, uint8_t **packet, uint32_t *size)
                 {
                     if (q->flags & LIBNET_PBLOCK_DO_CHECKSUM)
                     {
-                        uint32_t c;
                         uint8_t* end = *packet + l->aligner + l->total_size;
                         uint8_t* beg = *packet + n;
                         int ip_offset = calculate_ip_offset(l, q);

--- a/src/libnet_port_list.c
+++ b/src/libnet_port_list.c
@@ -101,6 +101,7 @@ libnet_plist_chain_new(libnet_t *l, libnet_plist_t **plist, char *token_list)
         all_lists = all_lists_tmp;
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                     "libnet_build_plist_chain: realloc %s", strerror(errno));
+        free(tmp);
         *plist = NULL;
         return(-1);
     }


### PR DESCRIPTION
I tried to compile libnet with `-fanalyzer` and tried to fix a few of the warnings.

There are more warnings, but it seems a couple of them are false positives. The warnings fixed in this PR seemed correct, however.