### PR TITLE
Fix malloc return value checking; Fix potential memory leak

### DIFF
--- a/src/libnet_cq.c
+++ b/src/libnet_cq.c
@@ -128,7 +128,7 @@ libnet_cq_add(libnet_t *l, char *label)
     }
 
     new = (libnet_cq_t *)malloc(sizeof (libnet_cq_t));
-    if (l_cq == NULL)
+    if (new == NULL)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                 "%s(): can't malloc new context queue: %s",


### PR DESCRIPTION
It's seems like a mistake in checking malloc return value. It's may lead to memory leak.
Thank you for review:)