### PR TITLE
Move status output message after check for NULL pointer

### DIFF
--- a/sample/ip_link.c
+++ b/sample/ip_link.c
@@ -110,13 +110,13 @@ main(int argc, char *argv[])
 	    device,                                 /* network interface */
             errbuf);                                /* error buffer */
 
-    printf("Using device %s\n", l->device);
-
     if (l == NULL)
     {
         fprintf(stderr, "libnet_init() failed: %s", errbuf);
         exit(EXIT_FAILURE); 
     }
+
+    printf("Using device %s\n", l->device);
 
     if ((dst_ip = libnet_name2addr4(l, dst, LIBNET_RESOLVE)) == -1)
     {

--- a/sample/ip_raw.c
+++ b/sample/ip_raw.c
@@ -103,13 +103,13 @@ main(int argc, char *argv[])
 	    device,                                 /* network interface */
             errbuf);                                /* error buffer */
 
-    printf("Using device %s\n", l->device);
-
     if (l == NULL)
     {
         fprintf(stderr, "libnet_init() failed: %s", errbuf);
         exit(EXIT_FAILURE); 
     }
+
+    printf("Using device %s\n", l->device);
 
     if ((dst_ip = libnet_name2addr4(l, dst, LIBNET_RESOLVE)) == -1)
     {


### PR DESCRIPTION
If libnet_init() fails the sample code will segfault when trying to dereference the l pointer handle.
This patch will move the error checking before the status output message.