### PR TITLE
libnet_raw: don't change the TX buffer size for raw sockets

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@ of contributors, see the GIT commit log.
 
 ### Changes
 
+- Don't try to configure TX buffer max size for every raw socket. Instead, add a new API
+  that can be used when needed, called `libnet_setfd_max_sndbuf()`.
+
 ### Fixes
 
 

--- a/include/libnet/libnet-functions.h
+++ b/include/libnet/libnet-functions.h
@@ -101,6 +101,18 @@ LIBNET_API
 int 
 libnet_getfd(libnet_t *l);
 
+#ifdef SO_SNDBUF
+/**
+ * Tries to set the TX buffer size to a max_bytes value
+ * @param l pointer to a libnet context
+ * @param max_bytes new TX buffer size
+ * @return 0 on success, -1 on failure
+ */
+LIBNET_API
+int 
+libnet_setfd_max_sndbuf(libnet_t *l, int max_bytes);
+#endif /* SO_SNDBUF */
+
 /**
  * Returns the canonical name of the device used for packet injection.
  * @param l pointer to a libnet context

--- a/src/libnet_init.c
+++ b/src/libnet_init.c
@@ -172,6 +172,26 @@ libnet_getfd(libnet_t *l)
     return (int)(l->fd);
 }
 
+#ifdef SO_SNDBUF
+int
+libnet_setfd_max_sndbuf(libnet_t *l, int max_bytes)
+{
+    if (l == NULL)
+        return (-1);
+
+    /* Try to set the buffer size to max_bytes */
+    if (setsockopt(l->fd, SOL_SOCKET, SO_SNDBUF, &max_bytes, sizeof(max_bytes)) < 0)
+    {
+        snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
+                    "%s(): set SO_SNDBUF failed: %s",
+                    __func__, strerror(errno));
+        return (-1);
+    }
+
+    return (0);
+}
+#endif /* SO_SNDBUF */
+
 const char *
 libnet_getdevice(libnet_t *l)
 {

--- a/src/libnet_raw.c
+++ b/src/libnet_raw.c
@@ -79,40 +79,6 @@ static int libnet_finish_setup_socket(libnet_t *l)
 #endif
     unsigned len;
 
-#ifdef SO_SNDBUF
-
-/*
- * man 7 socket 
- *
- * Sets and  gets  the  maximum  socket  send buffer in bytes. 
- *
- * Taken from libdnet by Dug Song
- */
-    len = sizeof(n);
-    if (getsockopt(l->fd, SOL_SOCKET, SO_SNDBUF, &n, &len) < 0)
-    {
-        snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
-		 "%s(): get SO_SNDBUF failed: %s",
-		 __func__, strerror(errno));
-        goto bad;
-    }
-    
-    for (n += 128; n < 1048576; n += 128)
-    {
-        if (setsockopt(l->fd, SOL_SOCKET, SO_SNDBUF, &n, len) < 0)
-        {
-            if (errno == ENOBUFS)
-            {
-                break;
-            }
-             snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
-                     "%s(): set SO_SNDBUF failed: %s",
-                     __func__, strerror(errno));
-             goto bad;
-        }
-    }
-#endif
-
 #ifdef SO_BROADCAST
 /*
  * man 7 socket
@@ -145,9 +111,6 @@ static int libnet_finish_setup_socket(libnet_t *l)
 bad:
     return (-1);
 }
-
-
-
 
 int
 libnet_open_raw4(libnet_t *l)


### PR DESCRIPTION
While doing some investigation around syscall usage on one of my apps that use libnet, I noticed the following piece of code that tries to configure the TX buffer size for raw sockets as close to 1MB as possible (the default for this on most Linux systems seems to be around 200K).

Because of this loop, for every libnet raw context initialization, there are over 6500 setsockopt syscalls generated, for no obvious reason.

Simple test on udp1.c sample, before change:
```
$ sudo strace -c -f ./udp1 -s 192.168.4.1 -d 192.168.4.2
Running with: libnet version 1.3-dev
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
Packets sent:  10
Packet errors: 0
Bytes written: 480
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 98.25    0.014458           2      6529           setsockopt
  1.21    0.000178           8        22           write
  0.48    0.000071           7        10           sendto
  0.06    0.000009           2         4           close
  0.00    0.000000           0         2           read
  0.00    0.000000           0         4           fstat
  0.00    0.000000           0        13           mmap
  0.00    0.000000           0         4           mprotect
  0.00    0.000000           0         1           munmap
  0.00    0.000000           0         3           brk
  0.00    0.000000           0         6           pread64
  0.00    0.000000           0         1         1 access
  0.00    0.000000           0         1           socket
  0.00    0.000000           0         1           getsockopt
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         2         1 arch_prctl
  0.00    0.000000           0         3           openat
------ ----------- ----------- --------- --------- ----------------
100.00    0.014716                  6607         2 total
```

After change:
```
$ sudo strace -c -f ./udp1 -s 192.168.4.1 -d 192.168.4.2
Running with: libnet version 1.3-dev
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
48 byte packet, ready to go
Wrote 48 byte UDP packet; check the wire.
Packets sent:  10
Packet errors: 0
Bytes written: 480
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 40.12    0.000067           6        10           sendto
 34.13    0.000057           2        22           write
 25.75    0.000043          10         4           close
  0.00    0.000000           0         2           read
  0.00    0.000000           0         4           fstat
  0.00    0.000000           0        13           mmap
  0.00    0.000000           0         4           mprotect
  0.00    0.000000           0         1           munmap
  0.00    0.000000           0         3           brk
  0.00    0.000000           0         6           pread64
  0.00    0.000000           0         1         1 access
  0.00    0.000000           0         1           socket
  0.00    0.000000           0         2           setsockopt
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         2         1 arch_prctl
  0.00    0.000000           0         3           openat
------ ----------- ----------- --------- --------- ----------------
100.00    0.000167                    79         2 total
```

Can anyone let me know about the history behind this? Can we drop this piece of code as it seem to generate a lot of unneeded syscalls?

Thanks,
Beni