### PR TITLE
const wherever possible

### DIFF
--- a/include/libnet/libnet-asn1.h
+++ b/include/libnet/libnet-asn1.h
@@ -117,7 +117,7 @@ libnet_build_asn1_int(
     uint8_t *,           /* Pointer to the output buffer */
     int *,              /* Number of valid bytes left in the buffer */
     uint8_t,             /* ASN object type */
-    int32_t *,             /* Pointer to a int32_t integer */
+    const int32_t *,       /* Pointer to a int32_t integer */
     int                 /* Size of a int32_t integer */
     );
 
@@ -134,7 +134,7 @@ libnet_build_asn1_uint(
     uint8_t *,           /* Pointer to the output buffer */
     int *,              /* Number of valid bytes left in the buffer */
     uint8_t,             /* ASN object type */
-    uint32_t *,           /* Pointer to an unsigned int32_t integer */
+    const uint32_t *,     /* Pointer to an unsigned int32_t integer */
     int                 /* Size of a int32_t integer */
     );
 
@@ -151,7 +151,7 @@ libnet_build_asn1_string(
     uint8_t *,           /* Pointer to the output buffer */
     int *,              /* Number of valid bytes left in the buffer */
     uint8_t,             /* ASN object type */
-    uint8_t *,           /* Pointer to a string to be built into an object */
+    const uint8_t *,     /* Pointer to a string to be built into an object */
     int                 /* Size of the string */
     );
 
@@ -245,8 +245,8 @@ libnet_build_asn1_bitstring(
     uint8_t *,
     int *,
     uint8_t,
-    uint8_t *,       /* Pointer to the input buffer */
-    int             /* Length of the input buffer */
+    const uint8_t *,       /* Pointer to the input buffer */
+    int                   /* Length of the input buffer */
     );
 
 

--- a/include/libnet/libnet-functions.h
+++ b/include/libnet/libnet-functions.h
@@ -90,7 +90,7 @@ libnet_clear_packet(libnet_t *l);
  */
 LIBNET_API
 void
-libnet_stats(libnet_t *l, struct libnet_stats *ls);
+libnet_stats(const libnet_t *l, struct libnet_stats *ls);
 
 /**
  * Returns the FILENO of the file descriptor used for packet injection.
@@ -99,7 +99,7 @@ libnet_stats(libnet_t *l, struct libnet_stats *ls);
  */
 LIBNET_API
 int 
-libnet_getfd(libnet_t *l);
+libnet_getfd(const libnet_t *l);
 
 #ifdef SO_SNDBUF
 /**
@@ -121,7 +121,7 @@ libnet_setfd_max_sndbuf(libnet_t *l, int max_bytes);
  */
 LIBNET_API
 const char *
-libnet_getdevice(libnet_t *l);
+libnet_getdevice(const libnet_t *l);
 
 /**
  * Returns the pblock buffer contents for the specified ptag; a
@@ -156,7 +156,7 @@ libnet_getpbuf_size(libnet_t *l, libnet_ptag_t ptag);
  */ 
 LIBNET_API
 char *
-libnet_geterror(libnet_t *l);
+libnet_geterror(const libnet_t *l);
 
 /**
  * Returns the sum of the size of all of the pblocks inside of l (this should
@@ -166,7 +166,7 @@ libnet_geterror(libnet_t *l);
  */ 
 LIBNET_API
 uint32_t
-libnet_getpacket_size(libnet_t *l);
+libnet_getpacket_size(const libnet_t *l);
 
 /**
  * Seeds the pseudo-random number generator.
@@ -520,7 +520,7 @@ const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
 LIBNET_API
 libnet_ptag_t
 libnet_build_802_2snap(uint8_t dsap, uint8_t ssap, uint8_t control, 
-uint8_t *oui, uint16_t type, const uint8_t* payload, uint32_t payload_s,
+const uint8_t *oui, uint16_t type, const uint8_t* payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag); 
 
 /**
@@ -766,8 +766,8 @@ libnet_t *l, libnet_ptag_t ptag);
  * @retval -1 on error
  */
 LIBNET_API
-libnet_ptag_t libnet_build_lldp_chassis(const uint8_t subtype,
-const uint8_t *value, const uint8_t value_s,
+libnet_ptag_t libnet_build_lldp_chassis(uint8_t subtype,
+const uint8_t *value, uint8_t value_s,
 libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -781,8 +781,8 @@ libnet_t *l, libnet_ptag_t ptag);
  * @retval -1 on error
  */
 LIBNET_API
-libnet_ptag_t libnet_build_lldp_port(const uint8_t subtype,
-const uint8_t *value, const uint8_t value_s,
+libnet_ptag_t libnet_build_lldp_port(uint8_t subtype,
+const uint8_t *value, uint8_t value_s,
 libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -794,7 +794,7 @@ libnet_t *l, libnet_ptag_t ptag);
  * @retval -1 on error
  */
 LIBNET_API
-libnet_ptag_t libnet_build_lldp_ttl(const uint16_t ttl,
+libnet_ptag_t libnet_build_lldp_ttl(uint16_t ttl,
 libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -820,7 +820,7 @@ libnet_ptag_t libnet_build_lldp_end(libnet_t *l, libnet_ptag_t ptag);
  */
 LIBNET_API
 libnet_ptag_t libnet_build_lldp_org_spec(const uint8_t *value,
-const uint16_t value_s, libnet_t *l, libnet_ptag_t ptag);
+uint16_t value_s, libnet_t *l, libnet_ptag_t ptag);
 
 /**
  * At the moment, this function is not implemented.
@@ -976,8 +976,8 @@ const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
  */
 LIBNET_API
 libnet_ptag_t libnet_build_icmpv6_echo(uint8_t type, uint8_t code, uint16_t
-        sum, uint16_t id, uint16_t seq, uint8_t *payload, uint32_t payload_s,
-        libnet_t *l, libnet_ptag_t ptag);
+        sum, uint16_t id, uint16_t seq, const uint8_t *payload,
+        uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
 
 /**
  * Builds an IP version 6 RFC 4443 Internet Control Message Protocol (ICMP)
@@ -997,7 +997,7 @@ libnet_ptag_t libnet_build_icmpv6_echo(uint8_t type, uint8_t code, uint16_t
 LIBNET_API
 libnet_ptag_t
 libnet_build_icmpv6_unreach(uint8_t type, uint8_t code, uint16_t sum,
-uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
+const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
 
 /**
  * Builds an IP version 6 RFC 2461 Internet Control Message Protocol (ICMP)
@@ -1016,8 +1016,8 @@ uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
  */
 LIBNET_API
 libnet_ptag_t libnet_build_icmpv6_ndp_nsol(uint8_t type, uint8_t code,
-        uint16_t sum, struct libnet_in6_addr target, uint8_t *payload, uint32_t
-        payload_s, libnet_t* l, libnet_ptag_t ptag);
+        uint16_t sum, struct libnet_in6_addr target, const uint8_t *payload,
+        uint32_t payload_s, libnet_t* l, libnet_ptag_t ptag);
 
 /**
  * Builds an IP version 6 RFC 2461 Internet Control Message Protocol (ICMP)
@@ -1037,8 +1037,9 @@ libnet_ptag_t libnet_build_icmpv6_ndp_nsol(uint8_t type, uint8_t code,
  */
 LIBNET_API
 libnet_ptag_t libnet_build_icmpv6_ndp_nadv(uint8_t type, uint8_t code,
-        uint16_t sum, uint32_t flags, struct libnet_in6_addr target, uint8_t
-        *payload, uint32_t payload_s, libnet_t* l, libnet_ptag_t ptag);
+        uint16_t sum, uint32_t flags, struct libnet_in6_addr target,
+        const uint8_t *payload, uint32_t payload_s, libnet_t* l,
+        libnet_ptag_t ptag);
 
 /**
  * Builds ICMPv6 NDP options.
@@ -1051,7 +1052,7 @@ libnet_ptag_t libnet_build_icmpv6_ndp_nadv(uint8_t type, uint8_t code,
  * @retval -1 on error
  */
 LIBNET_API
-libnet_ptag_t libnet_build_icmpv6_ndp_opt(uint8_t type, uint8_t* option,
+libnet_ptag_t libnet_build_icmpv6_ndp_opt(uint8_t type, const uint8_t *option,
         uint32_t option_s, libnet_t* l, libnet_ptag_t ptag);
 
 /**
@@ -1288,8 +1289,8 @@ libnet_t *l, libnet_ptag_t ptag);
  */
 LIBNET_API
 libnet_ptag_t
-libnet_build_isl(uint8_t *dhost, uint8_t type, uint8_t user,
-uint8_t *shost, uint16_t len, const uint8_t *snap, uint16_t vid,
+libnet_build_isl(const uint8_t *dhost, uint8_t type, uint8_t user,
+const uint8_t *shost, uint16_t len, const uint8_t *snap, uint16_t vid,
 uint16_t portindex, uint16_t reserved, const uint8_t* payload,
 uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
 
@@ -1424,7 +1425,7 @@ LIBNET_API
 libnet_ptag_t
 libnet_build_rpc_call(uint32_t rm, uint32_t xid, uint32_t prog_num,
 uint32_t prog_vers, uint32_t procedure, uint32_t cflavor, uint32_t clength,
-uint8_t *cdata, uint32_t vflavor, uint32_t vlength, const uint8_t *vdata,
+const uint8_t *cdata, uint32_t vflavor, uint32_t vlength, const uint8_t *vdata,
 const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -1508,7 +1509,7 @@ const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
  */
 LIBNET_API
 libnet_ptag_t
-libnet_build_udld_device_id(const uint8_t *value, const uint8_t value_s,
+libnet_build_udld_device_id(const uint8_t *value, uint8_t value_s,
 libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -1522,7 +1523,7 @@ libnet_t *l, libnet_ptag_t ptag);
  */
 LIBNET_API
 libnet_ptag_t
-libnet_build_udld_port_id(const uint8_t *value, const uint8_t value_s,
+libnet_build_udld_port_id(const uint8_t *value, uint8_t value_s,
 libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -1536,7 +1537,7 @@ libnet_t *l, libnet_ptag_t ptag);
  */
 LIBNET_API
 libnet_ptag_t
-libnet_build_udld_echo(const uint8_t *value, const uint8_t value_s,
+libnet_build_udld_echo(const uint8_t *value, uint8_t value_s,
 libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -1576,7 +1577,7 @@ libnet_ptag_t ptag);
  */
 LIBNET_API
 libnet_ptag_t
-libnet_build_udld_device_name(const uint8_t *value, const uint8_t value_s,
+libnet_build_udld_device_name(const uint8_t *value, uint8_t value_s,
 libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -2080,8 +2081,8 @@ const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
 LIBNET_API
 libnet_ptag_t
 libnet_build_gre_sre(uint16_t af, uint8_t offset, uint8_t length,
-uint8_t *routing, const uint8_t* payload, uint32_t payload_s, libnet_t *l,
-libnet_ptag_t ptag);
+const uint8_t *routing, const uint8_t* payload, uint32_t payload_s,
+libnet_t *l, libnet_ptag_t ptag);
 
 /**
  * @param l pointer to a libnet context
@@ -2164,7 +2165,7 @@ LIBNET_API
 libnet_ptag_t
 libnet_build_bgp4_update(uint16_t unfeasible_rt_len, const uint8_t *withdrawn_rt,
 uint16_t total_path_attr_len, const uint8_t *path_attributes, uint16_t info_len,
-uint8_t *reachability_info, const uint8_t* payload, uint32_t payload_s,
+const uint8_t *reachability_info, const uint8_t* payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -2211,7 +2212,7 @@ LIBNET_API
 libnet_ptag_t
 libnet_build_sebek(uint32_t magic, uint16_t version, uint16_t type, 
 uint32_t counter, uint32_t time_sec, uint32_t time_usec, uint32_t pid,
-uint32_t uid, uint32_t fd, uint8_t cmd[SEBEK_CMD_LENGTH], uint32_t length, 
+uint32_t uid, uint32_t fd, const uint8_t cmd[SEBEK_CMD_LENGTH], uint32_t length, 
 const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
 
 /**
@@ -2238,8 +2239,9 @@ LIBNET_API
 libnet_ptag_t
 libnet_build_hsrp(uint8_t version, uint8_t opcode, uint8_t state, 
 uint8_t hello_time, uint8_t hold_time, uint8_t priority, uint8_t group,
-uint8_t reserved, uint8_t authdata[HSRP_AUTHDATA_LENGTH], uint32_t virtual_ip,
-const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
+uint8_t reserved, const uint8_t authdata[HSRP_AUTHDATA_LENGTH],
+uint32_t virtual_ip, const uint8_t* payload, uint32_t payload_s, libnet_t *l,
+libnet_ptag_t ptag);
 
 /**
  * Builds a link layer header for an initialized l. The function
@@ -2435,7 +2437,7 @@ libnet_adv_write_raw_ipv4(libnet_t *l, const uint8_t *packet, uint32_t packet_s)
  */
 LIBNET_API
 void
-libnet_adv_free_packet(libnet_t *l, uint8_t *packet);
+libnet_adv_free_packet(const libnet_t *l, uint8_t *packet);
 
 /**
  * [Context Queue] 
@@ -2452,7 +2454,7 @@ libnet_adv_free_packet(libnet_t *l, uint8_t *packet);
  * @retval -1 on failure
 */
 int 
-libnet_cq_add(libnet_t *l, char *label);
+libnet_cq_add(libnet_t *l, const char *label);
 
 /**
  * [Context Queue] 
@@ -2487,7 +2489,7 @@ libnet_cq_remove(libnet_t *l);
  */
 LIBNET_API   
 libnet_t *
-libnet_cq_remove_by_label(char *label);
+libnet_cq_remove_by_label(const char *label);
  
 /**
  * [Context Queue] 
@@ -2497,7 +2499,7 @@ libnet_cq_remove_by_label(char *label);
  */
 LIBNET_API   
 const char *
-libnet_cq_getlabel(libnet_t *l);
+libnet_cq_getlabel(const libnet_t *l);
  
 /**
  * [Context Queue] 
@@ -2508,7 +2510,7 @@ libnet_cq_getlabel(libnet_t *l);
  */
 LIBNET_API
 libnet_t *
-libnet_cq_find_by_label(char *label);
+libnet_cq_find_by_label(const char *label);
   
 /**
  * [Context Queue] 
@@ -2587,7 +2589,7 @@ libnet_cq_end_loop(void);
  */
 LIBNET_API
 void
-libnet_diag_dump_context(libnet_t *l);
+libnet_diag_dump_context(const libnet_t *l);
 
 /**
  * [Diagnostic] 
@@ -2596,7 +2598,7 @@ libnet_diag_dump_context(libnet_t *l);
  */
 LIBNET_API
 void
-libnet_diag_dump_pblock(libnet_t *l);
+libnet_diag_dump_pblock(const libnet_t *l);
 
 /**
  * [Diagnostic] 
@@ -2657,7 +2659,7 @@ libnet_open_raw4(libnet_t *l);
  */
 LIBNET_API
 int
-libnet_close_raw4(libnet_t *l);
+libnet_close_raw4(const libnet_t *l);
 
 /*
  * [Internal] 
@@ -2669,7 +2671,7 @@ libnet_open_raw6(libnet_t *l);
  * [Internal] 
  */
 int
-libnet_close_raw6(libnet_t *l);
+libnet_close_raw6(const libnet_t *l);
 
 /*
  * [Internal] 
@@ -2687,7 +2689,7 @@ libnet_open_link(libnet_t *l);
  * [Internal] 
  */
 int
-libnet_close_link(libnet_t *l);
+libnet_close_link(const libnet_t *l);
 
 /*
  * [Internal]
@@ -2724,21 +2726,21 @@ libnet_inet_checksum(libnet_t *l, uint8_t *iphdr, int protocol, int h_len, const
  */
 LIBNET_API
 uint32_t
-libnet_compute_crc(uint8_t *buf, uint32_t len);
+libnet_compute_crc(const uint8_t *buf, uint32_t len);
 
 /*
  * [Internal] 
  */
 LIBNET_API
 uint16_t
-libnet_ip_check(uint16_t *addr, int len);
+libnet_ip_check(const uint16_t *addr, int len);
 
 /*
  * [Internal] 
  */
 LIBNET_API
 int
-libnet_in_cksum(uint16_t *addr, int len);
+libnet_in_cksum(const uint16_t *addr, int len);
 
 /*
  * [Internal] 
@@ -2860,7 +2862,7 @@ libnet_win32_get_remote_mac(libnet_t *l, DWORD IP);
  * [Internal] 
  */
 int
-libnet_close_link_interface(libnet_t *l);
+libnet_close_link_interface(const libnet_t *l);
 
 /*
  * [Internal] 

--- a/include/libnet/libnet-functions.h
+++ b/include/libnet/libnet-functions.h
@@ -2659,7 +2659,7 @@ libnet_open_raw4(libnet_t *l);
  */
 LIBNET_API
 int
-libnet_close_raw4(const libnet_t *l);
+libnet_close_raw4(libnet_t *l);
 
 /*
  * [Internal] 
@@ -2671,7 +2671,7 @@ libnet_open_raw6(libnet_t *l);
  * [Internal] 
  */
 int
-libnet_close_raw6(const libnet_t *l);
+libnet_close_raw6(libnet_t *l);
 
 /*
  * [Internal] 
@@ -2689,7 +2689,7 @@ libnet_open_link(libnet_t *l);
  * [Internal] 
  */
 int
-libnet_close_link(const libnet_t *l);
+libnet_close_link(libnet_t *l);
 
 /*
  * [Internal]
@@ -2862,7 +2862,7 @@ libnet_win32_get_remote_mac(libnet_t *l, DWORD IP);
  * [Internal] 
  */
 int
-libnet_close_link_interface(const libnet_t *l);
+libnet_close_link_interface(libnet_t *l);
 
 /*
  * [Internal] 

--- a/include/libnet/libnet-functions.h
+++ b/include/libnet/libnet-functions.h
@@ -156,7 +156,7 @@ libnet_getpbuf_size(libnet_t *l, libnet_ptag_t ptag);
  */ 
 LIBNET_API
 char *
-libnet_geterror(const libnet_t *l);
+libnet_geterror(libnet_t *l);
 
 /**
  * Returns the sum of the size of all of the pblocks inside of l (this should

--- a/src/libnet_advanced.c
+++ b/src/libnet_advanced.c
@@ -59,8 +59,6 @@ int
 libnet_adv_cull_header(libnet_t *l, libnet_ptag_t ptag, uint8_t **header,
         uint32_t *header_s)
 {
-    libnet_pblock_t *p;
-
     *header = NULL;
     *header_s = 0;
 
@@ -77,7 +75,7 @@ libnet_adv_cull_header(libnet_t *l, libnet_ptag_t ptag, uint8_t **header,
     }
 #endif
 
-    p = libnet_pblock_find(l, ptag);
+    const libnet_pblock_t *p = libnet_pblock_find(l, ptag);
     if (p == NULL)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
@@ -93,15 +91,13 @@ libnet_adv_cull_header(libnet_t *l, libnet_ptag_t ptag, uint8_t **header,
 int
 libnet_adv_write_link(libnet_t *l, const uint8_t *packet, uint32_t packet_s)
 {
-    ssize_t c;
-
     if (l->injection_type != LIBNET_LINK_ADV)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                 "%s(): advanced link mode not enabled", __func__);
         return (-1);
     }
-    c = libnet_write_link(l, packet, packet_s);
+    const ssize_t c = libnet_write_link(l, packet, packet_s);
 
     /* do statistics */
     if (c == (ssize_t)packet_s)
@@ -127,15 +123,13 @@ libnet_adv_write_link(libnet_t *l, const uint8_t *packet, uint32_t packet_s)
 int
 libnet_adv_write_raw_ipv4(libnet_t *l, const uint8_t *packet, uint32_t packet_s)
 {
-    ssize_t c;
-
     if (l->injection_type != LIBNET_RAW4_ADV)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                 "%s(): advanced raw4 mode not enabled", __func__);
         return (-1);
     }
-    c = libnet_write_raw_ipv4(l, packet, packet_s);
+    const ssize_t c = libnet_write_raw_ipv4(l, packet, packet_s);
 
     /* do statistics */
     if (c == (ssize_t)packet_s)
@@ -159,7 +153,7 @@ libnet_adv_write_raw_ipv4(libnet_t *l, const uint8_t *packet, uint32_t packet_s)
 }
 
 void
-libnet_adv_free_packet(libnet_t *l, uint8_t *packet)
+libnet_adv_free_packet(const libnet_t *l, uint8_t *packet)
 {
     /*
      *  Restore original pointer address so free won't complain about a

--- a/src/libnet_asn1.c
+++ b/src/libnet_asn1.c
@@ -58,8 +58,8 @@
 #include "common.h"
 
 uint8_t *
-libnet_build_asn1_int(uint8_t *data, int *datalen, uint8_t type, int32_t *int_p,
-            int int_s)
+libnet_build_asn1_int(uint8_t *data, int *datalen, uint8_t type,
+            const int32_t *int_p, int int_s)
 {
     /*
      *  ASN.1 integer ::= 0x02 asnlength byte {byte}*
@@ -109,8 +109,8 @@ libnet_build_asn1_int(uint8_t *data, int *datalen, uint8_t type, int32_t *int_p,
 
 
 uint8_t *
-libnet_build_asn1_uint(uint8_t *data, int *datalen, uint8_t type, uint32_t *int_p,
-            int int_s)
+libnet_build_asn1_uint(uint8_t *data, int *datalen, uint8_t type,
+            const uint32_t *int_p, int int_s)
 {
     /*
      *  ASN.1 integer ::= 0x02 asnlength byte {byte}*
@@ -181,7 +181,7 @@ libnet_build_asn1_uint(uint8_t *data, int *datalen, uint8_t type, uint32_t *int_
 
 uint8_t *
 libnet_build_asn1_string(uint8_t *data, int *datalen, uint8_t type,
-            uint8_t *string, int str_s)
+            const uint8_t *string, int str_s)
 {
 
     /*
@@ -237,7 +237,7 @@ libnet_build_asn1_sequence(uint8_t *data, int *datalen, uint8_t type, int len)
 uint8_t *
 libnet_build_asn1_length(uint8_t *data, int *datalen, int len)
 {
-    uint8_t *start_data = data;
+    uint8_t * const start_data = data;
 
     /* no indefinite lengths sent */
     if (len < 0x80)
@@ -286,7 +286,6 @@ libnet_build_asn1_objid(uint8_t *data, int *datalen, uint8_t type, oid *objid,
     oid *op = objid;
     uint8_t objid_size[MAX_OID_LEN];
     uint32_t objid_val;
-    uint32_t first_objid_val;
     int i;
 
     /* check if there are at least 2 sub-identifiers */
@@ -302,7 +301,7 @@ libnet_build_asn1_objid(uint8_t *data, int *datalen, uint8_t type, oid *objid,
         objid_val = (op[0] * 40) + op[1];
         op += 2;
     }
-    first_objid_val = objid_val;
+    const uint32_t first_objid_val = objid_val;
 
     /* calculate the number of bytes needed to store the encoded value */
     for (i = 1, asnlen = 0;;)
@@ -405,7 +404,7 @@ libnet_build_asn1_null(uint8_t *data, int *datalen, uint8_t type)
 
 uint8_t *
 libnet_build_asn1_bitstring(uint8_t *data, int *datalen, uint8_t type,
-            uint8_t *string, int str_s)
+            const uint8_t *string, int str_s)
 {
 
     /*

--- a/src/libnet_build_802.1q.c
+++ b/src/libnet_build_802.1q.c
@@ -37,8 +37,7 @@ libnet_build_802_1q(const uint8_t *dst, const uint8_t *src, uint16_t tpi,
 uint8_t priority, uint8_t cfi, uint16_t vlan_id, uint16_t len_proto,
 const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_802_1q_hdr _802_1q_hdr;
 
     if (l == NULL)
@@ -47,13 +46,17 @@ const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_802_1Q_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_802_1Q_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_802_1Q_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_802.1x.c
+++ b/src/libnet_build_802.1x.c
@@ -36,8 +36,7 @@ libnet_ptag_t
 libnet_build_802_1x(uint8_t eap_ver, uint8_t eap_type, uint16_t length,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_802_1x_hdr dot1x_hdr;
 
     if (l == NULL)
@@ -46,13 +45,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_802_1X_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_802_1X_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_802_1X_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_802.2.c
+++ b/src/libnet_build_802.2.c
@@ -36,8 +36,7 @@ libnet_ptag_t
 libnet_build_802_2(uint8_t dsap, uint8_t ssap, uint8_t control, 
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_802_2_hdr _802_2_hdr;
 
     if (l == NULL)
@@ -46,13 +45,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_802_2_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_802_2_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_802_2_H);
     if (p == NULL)
     {
         return (-1);
@@ -81,11 +84,10 @@ bad:
 
 libnet_ptag_t
 libnet_build_802_2snap(uint8_t dsap, uint8_t ssap, uint8_t control,
-uint8_t *oui, uint16_t type, const uint8_t *payload, uint32_t payload_s,
+const uint8_t *oui, uint16_t type, const uint8_t *payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_802_2snap_hdr _802_2_hdr;
 
     if (l == NULL)
@@ -94,13 +96,17 @@ libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_802_2SNAP_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_802_2SNAP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_802_2SNAP_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_802.3.c
+++ b/src/libnet_build_802.3.c
@@ -36,8 +36,7 @@ libnet_ptag_t
 libnet_build_802_3(const uint8_t *dst, const uint8_t *src, uint16_t len, 
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_802_3_hdr _802_3_hdr;
 
     if (l == NULL)
@@ -46,13 +45,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_802_3_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_802_3_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_802_3_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_arp.c
+++ b/src/libnet_build_arp.c
@@ -38,8 +38,7 @@ libnet_build_arp(uint16_t hrd, uint16_t pro, uint8_t hln, uint8_t pln,
 uint16_t op, const uint8_t *sha, const uint8_t *spa, const uint8_t *tha, const uint8_t *tpa,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_arp_hdr arp_hdr;
 
     if (l == NULL)
@@ -48,13 +47,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     }
 
     n = LIBNET_ARP_H + (2 * hln) + (2 * pln) + payload_s;
-    h = 0;  /* ARP headers have no checksum */
+    const uint32_t h = 0;  /* ARP headers have no checksum */
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ARP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ARP_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_bgp.c
+++ b/src/libnet_build_bgp.c
@@ -37,8 +37,7 @@ libnet_build_bgp4_header(uint8_t marker[LIBNET_BGP4_MARKER_SIZE],
 uint16_t len, uint8_t type, const uint8_t *payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_bgp4_header_hdr bgp4_hdr;
 
     if (l == NULL)
@@ -47,13 +46,18 @@ libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_BGP4_HEADER_H + payload_s;   /* size of memory block */
-    h = 0;                                  /* BGP headers have no checksum */
+    /* BGP headers have no checksum */
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_BGP4_HEADER_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_BGP4_HEADER_H);
     if (p == NULL)
     {
         return (-1);
@@ -84,8 +88,7 @@ libnet_build_bgp4_open(uint8_t version, uint16_t src_as, uint16_t hold_time,
 uint32_t bgp_id, uint8_t opt_len, const uint8_t *payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     uint16_t val;
 
     if (l == NULL)
@@ -94,13 +97,18 @@ libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_BGP4_OPEN_H + payload_s;     /* size of memory block */
-    h = 0;                                  /* BGP msg have no checksum */
+    /* BGP msg have no checksum */
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_BGP4_OPEN_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_BGP4_OPEN_H);
     if (p == NULL)
     {
         return (-1);
@@ -148,11 +156,10 @@ bad:
 libnet_ptag_t
 libnet_build_bgp4_update(uint16_t unfeasible_rt_len, const uint8_t *withdrawn_rt,
 uint16_t total_path_attr_len, const uint8_t *path_attributes, uint16_t info_len,
-uint8_t *reachability_info, const uint8_t *payload, uint32_t payload_s,
+const uint8_t *reachability_info, const uint8_t *payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     uint16_t length;
 
     if (l == NULL)
@@ -165,13 +172,17 @@ libnet_t *l, libnet_ptag_t ptag)
             info_len + payload_s;
 
     /* BGP msg have no checksum */
-    h = 0;                                  
+    const uint32_t h = 0;                                  
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_BGP4_UPDATE_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_BGP4_UPDATE_H);
     if (p == NULL)
     {
         return (-1);
@@ -230,8 +241,7 @@ libnet_ptag_t
 libnet_build_bgp4_notification(uint8_t err_code, uint8_t err_subcode,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_bgp4_notification_hdr bgp4_hdr;
 
     if (l == NULL)
@@ -240,13 +250,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n =  LIBNET_BGP4_NOTIFICATION_H + + payload_s;    /* size of memory block */
-    h = 0; 
+    const uint32_t h = 0; 
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_BGP4_NOTIFICATION_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_BGP4_NOTIFICATION_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_cdp.c
+++ b/src/libnet_build_cdp.c
@@ -37,8 +37,7 @@ libnet_build_cdp(uint8_t version, uint8_t ttl, uint16_t sum, uint16_t type,
 uint16_t len, const uint8_t *value, const uint8_t *payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n,h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_cdp_hdr cdp_hdr;
 
     if (l == NULL)
@@ -47,13 +46,17 @@ libnet_t *l, libnet_ptag_t ptag)
     }
 
     n = LIBNET_CDP_H + LIBNET_CDP_H + len + payload_s;
-    h = LIBNET_CDP_H + LIBNET_CDP_H + len + payload_s;
+    const uint32_t h = LIBNET_CDP_H + LIBNET_CDP_H + len + payload_s;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_CDP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_CDP_H);
     if (p == NULL)
     {
         return (-1);
@@ -98,10 +101,9 @@ bad:
 
 int
 /* Not Yet Implemented */
-libnet_build_cdp_value(uint16_t type, uint16_t len, uint8_t *value, libnet_t *l,
-        libnet_ptag_t ptag)
+libnet_build_cdp_value(uint16_t type, uint16_t len, const uint8_t *value,
+        libnet_t *l, libnet_ptag_t ptag)
 {
-    libnet_pblock_t *p;
     struct libnet_cdp_value_hdr cdp_value_hdr;
 
     if (l == NULL)
@@ -112,7 +114,7 @@ libnet_build_cdp_value(uint16_t type, uint16_t len, uint8_t *value, libnet_t *l,
     /*
      *  Find the existing protocol block.
      */
-    p = libnet_pblock_find(l, ptag);
+    libnet_pblock_t * const p = libnet_pblock_find(l, ptag);
     if (p == NULL)
     {
         /* err msg set in libnet_pblock_find */

--- a/src/libnet_build_data.c
+++ b/src/libnet_build_data.c
@@ -37,8 +37,7 @@ libnet_ptag_t
 libnet_build_data(const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
 
     if (l == NULL)
     { 
@@ -46,13 +45,17 @@ libnet_ptag_t ptag)
     } 
 
     n = payload_s;
-    h = 0;          /* no checksum on generic block */
+    const uint32_t h = 0;          /* no checksum on generic block */
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_DATA_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_DATA_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_dhcp.c
+++ b/src/libnet_build_dhcp.c
@@ -38,9 +38,7 @@ uint8_t hopcount, uint32_t xid, uint16_t secs, uint16_t flags,
 uint32_t cip, uint32_t yip, uint32_t sip, uint32_t gip, const uint8_t *chaddr,
 const char *sname, const char *file, const uint8_t *payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag)
-{
-    uint32_t n, h;
-    libnet_pblock_t *p; 
+{ 
     struct libnet_dhcpv4_hdr dhcp_hdr;
 
     if (l == NULL)
@@ -48,14 +46,18 @@ libnet_t *l, libnet_ptag_t ptag)
         return (-1);
     } 
 
-    n = LIBNET_DHCPV4_H + payload_s;
-    h = 0;          /* no checksum */
+    const uint32_t n = LIBNET_DHCPV4_H + payload_s;
+    const uint32_t h = 0;          /* no checksum */
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_DHCPV4_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_DHCPV4_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_dns.c
+++ b/src/libnet_build_dns.c
@@ -40,9 +40,7 @@ libnet_build_dnsv4(uint16_t h_len, uint16_t id, uint16_t flags,
             libnet_t *l, libnet_ptag_t ptag)
 {
 
-    uint32_t n, h;
-    uint32_t offset;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_dnsv4_hdr dns_hdr;
 
     if (l == NULL)
@@ -56,15 +54,21 @@ libnet_build_dnsv4(uint16_t h_len, uint16_t id, uint16_t flags,
                 "%s(): invalid header length: %d", __func__, h_len);
        return (-1);
     }
-    offset = (h_len == LIBNET_UDP_DNSV4_H ? sizeof(dns_hdr.h_len) : 0);
+    const uint32_t offset = (h_len == LIBNET_UDP_DNSV4_H
+        ? sizeof(dns_hdr.h_len)
+        : 0);
     n = h_len + payload_s;
-    h = 0;          /* no checksum */
+    const uint32_t h = 0;          /* no checksum */
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_DNSV4_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_DNSV4_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_ethernet.c
+++ b/src/libnet_build_ethernet.c
@@ -116,7 +116,7 @@ libnet_autobuild_ethernet(const uint8_t *dst, uint16_t type, libnet_t *l)
     const uint32_t n = LIBNET_ETH_H;
     const uint32_t h = 0;
     const libnet_ptag_t ptag = LIBNET_PTAG_INITIALIZER;
-    const struct libnet_ether_addr * const src = libnet_get_hwaddr(l);
+    struct libnet_ether_addr * const src = libnet_get_hwaddr(l);
     if (src == NULL)
     {
         /* err msg set in libnet_get_hwaddr() */

--- a/src/libnet_build_ethernet.c
+++ b/src/libnet_build_ethernet.c
@@ -36,8 +36,7 @@ libnet_ptag_t
 libnet_build_ethernet(const uint8_t *dst, const uint8_t *src, uint16_t type, 
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_ethernet_hdr eth_hdr;
 
     if (l == NULL)
@@ -56,13 +55,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     }
 
     n = LIBNET_ETH_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ETH_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ETH_H);
     if (p == NULL)
     {
         return (-1);
@@ -91,10 +94,7 @@ bad:
 libnet_ptag_t
 libnet_autobuild_ethernet(const uint8_t *dst, uint16_t type, libnet_t *l)
 {
-    uint32_t n, h;
-    struct libnet_ether_addr *src;
     libnet_pblock_t *p;
-    libnet_ptag_t ptag;
     struct libnet_ethernet_hdr eth_hdr;
 
     if (l == NULL)
@@ -113,10 +113,10 @@ libnet_autobuild_ethernet(const uint8_t *dst, uint16_t type, libnet_t *l)
         goto bad;
     }
 
-    n = LIBNET_ETH_H;
-    h = 0;
-    ptag = LIBNET_PTAG_INITIALIZER;
-    src = libnet_get_hwaddr(l);
+    const uint32_t n = LIBNET_ETH_H;
+    const uint32_t h = 0;
+    const libnet_ptag_t ptag = LIBNET_PTAG_INITIALIZER;
+    const struct libnet_ether_addr * const src = libnet_get_hwaddr(l);
     if (src == NULL)
     {
         /* err msg set in libnet_get_hwaddr() */

--- a/src/libnet_build_fddi.c
+++ b/src/libnet_build_fddi.c
@@ -36,8 +36,7 @@ libnet_build_fddi(uint8_t fc, const uint8_t *dst, const uint8_t *src, uint8_t ds
 uint8_t ssap, uint8_t cf, const uint8_t *org, uint16_t type, const uint8_t *payload,
 uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    uint16_t protocol_type;
+    uint32_t n;
     libnet_pblock_t *p;
     struct libnet_fddi_hdr fddi_hdr;
 
@@ -58,7 +57,7 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     }
 
     n = LIBNET_FDDI_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
@@ -80,7 +79,7 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     memcpy(&fddi_hdr.fddi_llc_org_code, org, LIBNET_ORG_CODE_SIZE); 
 
     /* Deal with unaligned int16_t for type */
-    protocol_type = htons(type);
+    const uint16_t protocol_type = htons(type);
     memcpy(&fddi_hdr.fddi_type, &protocol_type, sizeof(int16_t));   /* Protocol Type */
 
     if (libnet_pblock_append(l, p, (uint8_t *)&fddi_hdr, LIBNET_FDDI_H) == -1)
@@ -102,11 +101,7 @@ libnet_ptag_t
 libnet_autobuild_fddi(uint8_t fc, const uint8_t *dst, uint8_t dsap, uint8_t ssap,
 uint8_t cf, const uint8_t *org, uint16_t type, libnet_t *l)
 {
-    uint32_t n, h;
-    uint16_t protocol_type;
-    struct libnet_fddi_addr *src;
     libnet_pblock_t *p;
-    libnet_ptag_t ptag;
     struct libnet_fddi_hdr fddi_hdr;
 
     if (l == NULL)
@@ -125,12 +120,12 @@ uint8_t cf, const uint8_t *org, uint16_t type, libnet_t *l)
         goto bad;
     }
 
-    n = LIBNET_FDDI_H;
-    h = 0;
-    ptag = LIBNET_PTAG_INITIALIZER;
+    const uint32_t n = LIBNET_FDDI_H;
+    const uint32_t h = 0;
+    const libnet_ptag_t ptag = LIBNET_PTAG_INITIALIZER;
 
     /* FDDI and Ethernet have the same address size - so just typecast */
-    src = (struct libnet_fddi_addr *) libnet_get_hwaddr(l);
+    struct libnet_fddi_addr * const src = (struct libnet_fddi_addr *) libnet_get_hwaddr(l);
     if (src == NULL)
     {
         /* err msg set in libnet_get_hwaddr() */
@@ -153,7 +148,7 @@ uint8_t cf, const uint8_t *org, uint16_t type, libnet_t *l)
     memcpy(&fddi_hdr.fddi_llc_org_code, org, LIBNET_ORG_CODE_SIZE); 
 
     /* Deal with unaligned int16_t for type */
-    protocol_type = htons(type);
+    const uint16_t protocol_type = htons(type);
     memcpy(&fddi_hdr.fddi_type, &protocol_type, sizeof(int16_t));
 
     if (libnet_pblock_append(l, p, (uint8_t *)&fddi_hdr, LIBNET_FDDI_H) == -1)

--- a/src/libnet_build_gre.c
+++ b/src/libnet_build_gre.c
@@ -2,7 +2,7 @@
  *  libnet
  *  libnet_build_gre.c - GRE packet assembler
  *
- *  Copyright (c) 2003 Frédéric Raynal <pappy@security-labs.org>
+ *  Copyright (c) 2003 Frï¿½dï¿½ric Raynal <pappy@security-labs.org>
  *  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -170,7 +170,6 @@ uint16_t offset, uint32_t key, uint32_t seq, uint16_t len,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
     uint32_t n;
-    libnet_pblock_t *p;
     struct libnet_gre_hdr gre_hdr;
 
     if (l == NULL)
@@ -184,7 +183,11 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_GRE_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_GRE_H);
     if (p == NULL)
     {
         return (-1);
@@ -285,11 +288,10 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
  */
 libnet_ptag_t
 libnet_build_gre_sre(uint16_t af, uint8_t offset, uint8_t length, 
-uint8_t *routing, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
-libnet_ptag_t ptag)
+const uint8_t *routing, const uint8_t *payload, uint32_t payload_s,
+libnet_t *l, libnet_ptag_t ptag)
 {
     uint32_t n;
-    libnet_pblock_t *p;
     struct libnet_gre_sre_hdr sre_hdr;
 
     if (l == NULL)
@@ -303,7 +305,11 @@ libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_GRE_SRE_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_GRE_SRE_H);
     if (p == NULL)
     {
         return (-1);
@@ -348,21 +354,24 @@ bad:
 libnet_ptag_t
 libnet_build_gre_last_sre(libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, zero = 0;
-    libnet_pblock_t *p;
+    const uint32_t zero = 0;
 
     if (l == NULL)
     { 
         return (-1); 
     }
 
-    n = LIBNET_GRE_SRE_H;
+    const uint32_t n = LIBNET_GRE_SRE_H;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_GRE_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_GRE_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_gre.c
+++ b/src/libnet_build_gre.c
@@ -2,7 +2,7 @@
  *  libnet
  *  libnet_build_gre.c - GRE packet assembler
  *
- *  Copyright (c) 2003 Fr�d�ric Raynal <pappy@security-labs.org>
+ *  Copyright (c) 2003 Frédéric Raynal <pappy@security-labs.org>
  *  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/libnet_build_hsrp.c
+++ b/src/libnet_build_hsrp.c
@@ -34,10 +34,10 @@
 libnet_ptag_t
 libnet_build_hsrp(uint8_t version, uint8_t opcode, uint8_t state, 
 uint8_t hello_time, uint8_t hold_time, uint8_t priority, uint8_t group,
-uint8_t reserved, uint8_t authdata[HSRP_AUTHDATA_LENGTH], uint32_t virtual_ip,
-const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
+uint8_t reserved, const uint8_t authdata[HSRP_AUTHDATA_LENGTH],
+uint32_t virtual_ip, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
+libnet_ptag_t ptag)
 {
-    libnet_pblock_t *p;
     struct libnet_hsrp_hdr hsrp_hdr;
 
     if (l == NULL)
@@ -49,7 +49,11 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, LIBNET_HSRP_H + payload_s, LIBNET_PBLOCK_HSRP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        LIBNET_HSRP_H + payload_s,
+        LIBNET_PBLOCK_HSRP_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_icmp.c
+++ b/src/libnet_build_icmp.c
@@ -586,7 +586,7 @@ libnet_ptag_t libnet_build_icmpv6_ndp_opt(
     assert((n % 8) == 0);
     assert(pad_s < sizeof(pad));
 
-    libnet_pblock_t* const p = libnet_pblock_probe(
+    libnet_pblock_t * const p = libnet_pblock_probe(
         l,
         ptag,
         n,

--- a/src/libnet_build_icmp.c
+++ b/src/libnet_build_icmp.c
@@ -69,8 +69,7 @@ libnet_build_icmpv4_echo(uint8_t type, uint8_t code, uint16_t sum,
 uint16_t id, uint16_t seq, const uint8_t *payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag) 
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_icmpv4_hdr icmp_hdr;
 
     if (l == NULL)
@@ -79,13 +78,17 @@ libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_ICMPV4_ECHO_H + payload_s;        /* size of memory block */
-    h = LIBNET_ICMPV4_ECHO_H + payload_s;        /* hl for checksum */
+    const uint32_t h = LIBNET_ICMPV4_ECHO_H + payload_s;        /* hl for checksum */
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ICMPV4_ECHO_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ICMPV4_ECHO_H);
     if (p == NULL)
     {
         return (-1);
@@ -127,8 +130,7 @@ libnet_build_icmpv4_mask(uint8_t type, uint8_t code, uint16_t sum,
 uint16_t id, uint16_t seq, uint32_t mask, const uint8_t *payload,
 uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_icmpv4_hdr icmp_hdr;
 
     if (l == NULL)
@@ -137,13 +139,18 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_ICMPV4_MASK_H + payload_s;        /* size of memory block */
-    h = LIBNET_ICMPV4_MASK_H + payload_s;        /* hl for checksum */
+    /* hl for checksum */
+    const uint32_t h = LIBNET_ICMPV4_MASK_H + payload_s;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ICMPV4_MASK_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ICMPV4_MASK_H);
     if (p == NULL)
     {
         return (-1);
@@ -187,8 +194,7 @@ libnet_build_icmpv4_timestamp(uint8_t type, uint8_t code, uint16_t sum,
 uint16_t id, uint16_t seq, uint32_t otime, uint32_t rtime, uint32_t ttime,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_icmpv4_hdr icmp_hdr;
 
     if (l == NULL)
@@ -197,13 +203,18 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_ICMPV4_TS_H + payload_s;        /* size of memory block */
-    h = LIBNET_ICMPV4_TS_H + payload_s;        /* hl for checksum */
+    /* hl for checksum */
+    const uint32_t h = LIBNET_ICMPV4_TS_H + payload_s;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ICMPV4_TS_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ICMPV4_TS_H);
     if (p == NULL)
     {
         return (-1);
@@ -248,28 +259,31 @@ libnet_ptag_t
 libnet_build_icmpv4_unreach(uint8_t type, uint8_t code, uint16_t sum,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
     struct libnet_icmpv4_hdr icmp_hdr;
 
     if (l == NULL)
     { 
         return (-1);
     } 
-    n = LIBNET_ICMPV4_UNREACH_H + payload_s;        /* size of memory block */
+    /* size of memory block */
+    const uint32_t n = LIBNET_ICMPV4_UNREACH_H + payload_s;
 
     /* 
      * FREDRAYNAL: as ICMP checksum includes what is embedded in 
      * the payload, and what is after the ICMP header, we need to include
      * those 2 sizes.
      */
-    h = LIBNET_ICMPV4_UNREACH_H + payload_s + l->total_size; 
+    const uint32_t h = LIBNET_ICMPV4_UNREACH_H + payload_s + l->total_size; 
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ICMPV4_UNREACH_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ICMPV4_UNREACH_H);
     if (p == NULL)
     {
         return (-1);
@@ -295,8 +309,6 @@ libnet_ptag_t
 libnet_build_icmpv4_timeexceed(uint8_t type, uint8_t code, uint16_t sum,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
     struct libnet_icmpv4_hdr icmp_hdr;
 
     if (l == NULL)
@@ -305,19 +317,23 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     /* size of memory block */
-    n = LIBNET_ICMPV4_TIMXCEED_H + payload_s;
+    const uint32_t n = LIBNET_ICMPV4_TIMXCEED_H + payload_s;
     /* 
      * FREDRAYNAL: as ICMP checksum includes what is embedded in 
      * the payload, and what is after the ICMP header, we need to include
      * those 2 sizes.
      */
-    h = LIBNET_ICMPV4_TIMXCEED_H + payload_s + l->total_size; 
+    const uint32_t h = LIBNET_ICMPV4_TIMXCEED_H + payload_s + l->total_size; 
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ICMPV4_TIMXCEED_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ICMPV4_TIMXCEED_H);
     if (p == NULL)
     {
         return (-1);
@@ -343,10 +359,7 @@ libnet_ptag_t
 libnet_build_icmpv4_redirect(uint8_t type, uint8_t code, uint16_t sum,
 uint32_t gateway, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
-
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
     struct libnet_icmpv4_hdr icmp_hdr;
 
     if (l == NULL)
@@ -354,19 +367,24 @@ libnet_ptag_t ptag)
         return (-1);
     } 
 
-    n = LIBNET_ICMPV4_REDIRECT_H + payload_s;               /* size of memory block */
+    /* size of memory block */
+    const uint32_t n = LIBNET_ICMPV4_REDIRECT_H + payload_s;
     /* 
      * FREDRAYNAL: as ICMP checksum includes what is embedded in 
      * the payload, and what is after the ICMP header, we need to include
      * those 2 sizes.
      */
-    h = LIBNET_ICMPV4_REDIRECT_H + payload_s + l->total_size; 
+    const uint32_t h = LIBNET_ICMPV4_REDIRECT_H + payload_s + l->total_size; 
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ICMPV4_REDIRECT_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ICMPV4_REDIRECT_H);
     if (p == NULL)
     {
         return (-1);
@@ -392,12 +410,10 @@ libnet_ptag_t
 libnet_build_icmpv6_common(
         uint8_t type, uint8_t code, uint16_t sum,
         const void* specific, uint32_t specific_s, uint8_t pblock_type,
-        uint8_t *payload, uint32_t payload_s,
+        const uint8_t *payload, uint32_t payload_s,
         libnet_t *l, libnet_ptag_t ptag
         )
 {
-    uint32_t n;
-    libnet_pblock_t *p;
     struct libnet_icmpv6_hdr icmp_hdr;
 
     if (l == NULL)
@@ -405,9 +421,9 @@ libnet_build_icmpv6_common(
         return (-1);
     } 
 
-    n = LIBNET_ICMPV6_COMMON_H + specific_s + payload_s;
+    const uint32_t n = LIBNET_ICMPV6_COMMON_H + specific_s + payload_s;
 
-    p = libnet_pblock_probe(l, ptag, n, pblock_type);
+    libnet_pblock_t * const p = libnet_pblock_probe(l, ptag, n, pblock_type);
 
     if (p == NULL)
     {
@@ -448,7 +464,7 @@ bad:
 }
 
 libnet_ptag_t libnet_build_icmpv6(uint8_t type, uint8_t code, uint16_t sum,
-                                  uint8_t* payload, uint32_t payload_s,
+                                  const uint8_t* payload, uint32_t payload_s,
                                   libnet_t* l, libnet_ptag_t ptag)
 {
     return libnet_build_icmpv6_common(
@@ -461,7 +477,7 @@ libnet_ptag_t libnet_build_icmpv6(uint8_t type, uint8_t code, uint16_t sum,
 libnet_ptag_t
 libnet_build_icmpv6_unreach(
         uint8_t type, uint8_t code, uint16_t sum,
-        uint8_t *payload, uint32_t payload_s,
+        const uint8_t *payload, uint32_t payload_s,
         libnet_t *l, libnet_ptag_t ptag
         )
 {
@@ -480,7 +496,7 @@ libnet_ptag_t
 libnet_build_icmpv6_echo(
         uint8_t type, uint8_t code, uint16_t sum,
         uint16_t id, uint16_t seq,
-        uint8_t *payload, uint32_t payload_s,
+        const uint8_t *payload, uint32_t payload_s,
         libnet_t *l, libnet_ptag_t ptag
         )
 {
@@ -501,7 +517,7 @@ libnet_build_icmpv6_echo(
 libnet_ptag_t libnet_build_icmpv6_ndp_nsol(
         uint8_t type, uint8_t code, uint16_t sum,
         struct libnet_in6_addr target,
-        uint8_t *payload, uint32_t payload_s,
+        const uint8_t *payload, uint32_t payload_s,
         libnet_t* l, libnet_ptag_t ptag)
 {
     struct libnet_icmpv6_ndp_nsol specific;
@@ -521,7 +537,7 @@ libnet_ptag_t libnet_build_icmpv6_ndp_nsol(
 libnet_ptag_t libnet_build_icmpv6_ndp_nadv(
         uint8_t type, uint8_t code, uint16_t sum,
         uint32_t flags, struct libnet_in6_addr target,
-        uint8_t *payload, uint32_t payload_s,
+        const uint8_t *payload, uint32_t payload_s,
         libnet_t* l, libnet_ptag_t ptag)
 {
 
@@ -539,14 +555,12 @@ libnet_ptag_t libnet_build_icmpv6_ndp_nadv(
 }
 
 libnet_ptag_t libnet_build_icmpv6_ndp_opt(
-        uint8_t type, uint8_t* option, uint32_t option_s,
+        uint8_t type, const uint8_t *option, uint32_t option_s,
         libnet_t* l, libnet_ptag_t ptag)
 {
     struct libnet_icmpv6_ndp_opt opt;
     uint32_t n;
-    static uint8_t pad[8] = { 0 };
-    uint32_t pad_s = 0;
-    libnet_pblock_t* p;
+    static const uint8_t pad[8] = { 0 };
 
     if(l == NULL)
         return -1;
@@ -567,12 +581,16 @@ libnet_ptag_t libnet_build_icmpv6_ndp_opt(
         return -1;
     }
 
-    pad_s = n - option_s - sizeof(opt);
+    const uint32_t pad_s = n - option_s - sizeof(opt);
 
     assert((n % 8) == 0);
     assert(pad_s < sizeof(pad));
 
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ICMPV6_NDP_OPT_H);
+    libnet_pblock_t* const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ICMPV6_NDP_OPT_H);
     if(p == NULL)
         return -1;
 

--- a/src/libnet_build_igmp.c
+++ b/src/libnet_build_igmp.c
@@ -36,8 +36,7 @@ libnet_ptag_t
 libnet_build_igmp(uint8_t type, uint8_t reserved, uint16_t sum, uint32_t ip,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_igmp_hdr igmp_hdr;
 
     if (l == NULL)
@@ -46,13 +45,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_IGMP_H + payload_s;
-    h = LIBNET_IGMP_H;
+    const uint32_t h = LIBNET_IGMP_H;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IGMP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IGMP_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_ip.c
+++ b/src/libnet_build_ip.c
@@ -38,11 +38,10 @@ libnet_build_ipv4(uint16_t ip_len, uint8_t tos, uint16_t id, uint16_t frag,
 uint8_t ttl, uint8_t prot, uint16_t sum, uint32_t src, uint32_t dst,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n = LIBNET_IPV4_H; /* size of memory block */
-    libnet_pblock_t *p, *p_data, *p_temp;
+    const uint32_t n = LIBNET_IPV4_H; /* size of memory block */
+    libnet_pblock_t *p_data, *p_temp;
     struct libnet_ipv4_hdr ip_hdr;
     libnet_ptag_t ptag_data = 0; /* used if there is ipv4 payload */
-    libnet_ptag_t ptag_hold;
 
     if (l == NULL)
     { 
@@ -53,7 +52,11 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPV4_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPV4_H);
     if (p == NULL)
     {
         return (-1);
@@ -96,7 +99,7 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     }
 
     /* save the original ptag value */
-    ptag_hold = ptag;
+    const libnet_ptag_t ptag_hold = ptag;
 
     if (ptag == LIBNET_PTAG_INITIALIZER)
     {
@@ -239,9 +242,7 @@ bad:
 libnet_ptag_t
 libnet_autobuild_ipv4(uint16_t len, uint8_t prot, uint32_t dst, libnet_t *l)
 {
-    uint32_t n, i, j, src;
-    uint16_t h;
-    libnet_pblock_t *p;
+    uint32_t i, j;
     libnet_ptag_t ptag;
     struct libnet_ipv4_hdr ip_hdr;
 
@@ -250,10 +251,10 @@ libnet_autobuild_ipv4(uint16_t len, uint8_t prot, uint32_t dst, libnet_t *l)
         return (-1);
     } 
 
-    n = LIBNET_IPV4_H;                                /* size of memory block */
-    h = len;                                          /* header length */
+    const uint32_t n = LIBNET_IPV4_H;                 /* size of memory block */
+    const uint16_t h = len;                                          /* header length */
     ptag = LIBNET_PTAG_INITIALIZER;
-    src = libnet_get_ipaddr4(l);
+    const uint32_t src = libnet_get_ipaddr4(l);
     if (src == UINT32_MAX)
     {
         /* err msg set in libnet_get_ipaddr() */ 
@@ -263,7 +264,11 @@ libnet_autobuild_ipv4(uint16_t len, uint8_t prot, uint32_t dst, libnet_t *l)
     /*
      *  Create a new pblock.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPV4_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPV4_H);
     if (p == NULL)
     {
         return (-1);
@@ -321,8 +326,7 @@ libnet_ptag_t ptag)
 {
     int options_size_increase = 0; /* increase will be negative if it's a decrease */
     uint32_t adj_size;
-    libnet_pblock_t *p, *p_temp;
-    struct libnet_ipv4_hdr *ip_hdr;
+    libnet_pblock_t *p_temp;
 
     if (l == NULL)
     { 
@@ -362,7 +366,11 @@ libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, adj_size, LIBNET_PBLOCK_IPO_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        adj_size,
+        LIBNET_PBLOCK_IPO_H);
     if (p == NULL)
     {
         return (-1);
@@ -387,7 +395,7 @@ libnet_ptag_t ptag)
         /* fix the IP header sizes */
         if (p_temp->type == LIBNET_PBLOCK_IPV4_H)
         {
-            ip_hdr = (struct libnet_ipv4_hdr *) p_temp->buf;
+            struct libnet_ipv4_hdr * const ip_hdr = (struct libnet_ipv4_hdr *) p_temp->buf;
             ip_hdr->ip_hl = 5 + adj_size / 4; /* 4 bits wide, so no byte order concerns */
             ip_hdr->ip_len = htons(ntohs(ip_hdr->ip_len) + options_size_increase);
 
@@ -408,7 +416,6 @@ uint8_t hl, struct libnet_in6_addr src, struct libnet_in6_addr dst,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {   
     uint32_t n;
-    libnet_pblock_t *p;
     struct libnet_ipv6_hdr ip_hdr;
 
     if (l == NULL)
@@ -429,7 +436,11 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPV6_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPV6_H);
     if (p == NULL)
     {   
         return (-1);
@@ -471,8 +482,6 @@ uint32_t id, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
 {
     uint32_t n;
-    uint16_t h;
-    libnet_pblock_t *p;
     struct libnet_ipv6_frag_hdr ipv6_frag_hdr;
 
     if (l == NULL)
@@ -481,7 +490,7 @@ libnet_ptag_t ptag)
     }
 
     n = LIBNET_IPV6_FRAG_H + payload_s;
-    h = 0; 
+    const uint16_t h = 0; 
 
     if (LIBNET_IPV6_FRAG_H + payload_s > IP_MAXPACKET)
     {
@@ -494,7 +503,11 @@ libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPV6_FRAG_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPV6_FRAG_H);
     if (p == NULL)
     {
         return (-1);
@@ -536,8 +549,6 @@ uint8_t segments, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
 {
     uint32_t n;
-    uint16_t h;
-    libnet_pblock_t *p;
     struct libnet_ipv6_routing_hdr ipv6_routing_hdr;
 
     if (l == NULL)
@@ -549,7 +560,7 @@ libnet_ptag_t ptag)
      * interface!
      */
     n = LIBNET_IPV6_ROUTING_H + payload_s;
-    h = 0;
+    const uint16_t h = 0;
 
     if (LIBNET_IPV6_ROUTING_H + payload_s > IP_MAXPACKET)
     {
@@ -562,7 +573,11 @@ libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPV6_ROUTING_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPV6_ROUTING_H);
     if (p == NULL)
     {
         return (-1);
@@ -603,8 +618,6 @@ libnet_build_ipv6_destopts(uint8_t nh, uint8_t len, const uint8_t *payload,
 uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
     uint32_t n;
-    uint16_t h;
-    libnet_pblock_t *p;
     struct libnet_ipv6_destopts_hdr ipv6_destopts_hdr;
 
     if (l == NULL)
@@ -616,7 +629,7 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      * interface!
      */
     n = LIBNET_IPV6_DESTOPTS_H + payload_s;
-    h = 0;
+    const uint16_t h = 0;
 
     if (LIBNET_IPV6_DESTOPTS_H + payload_s > IP_MAXPACKET)
     {
@@ -629,7 +642,11 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPV6_DESTOPTS_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPV6_DESTOPTS_H);
     if (p == NULL)
     {
         return (-1);
@@ -668,8 +685,6 @@ libnet_build_ipv6_hbhopts(uint8_t nh, uint8_t len, const uint8_t *payload,
 uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
     uint32_t n;
-    uint16_t h;
-    libnet_pblock_t *p;
     struct libnet_ipv6_hbhopts_hdr ipv6_hbhopts_hdr;
 
     if (l == NULL)
@@ -681,7 +696,7 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      * payload interface!
      */
     n = LIBNET_IPV6_HBHOPTS_H + payload_s;
-    h = 0;
+    const uint16_t h = 0;
 
     if (LIBNET_IPV6_HBHOPTS_H + payload_s > IP_MAXPACKET)
     {
@@ -694,7 +709,11 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPV6_HBHOPTS_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPV6_HBHOPTS_H);
     if (p == NULL)
     {
         return (-1);
@@ -732,9 +751,7 @@ libnet_ptag_t
 libnet_autobuild_ipv6(uint16_t len, uint8_t nh, struct libnet_in6_addr dst,
             libnet_t *l, libnet_ptag_t ptag)
 {
-    struct libnet_in6_addr src;
-
-    src = libnet_get_ipaddr6(l);
+    const struct libnet_in6_addr src = libnet_get_ipaddr6(l);
 
     if (libnet_in6_is_error(src))
     {

--- a/src/libnet_build_ipsec.c
+++ b/src/libnet_build_ipsec.c
@@ -37,8 +37,7 @@ libnet_ptag_t
 libnet_build_ipsec_esp_hdr(uint32_t spi, uint32_t seq, uint32_t iv,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_esp_hdr esp_hdr;
 
     if (l == NULL)
@@ -47,7 +46,7 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_IPSEC_ESP_HDR_H + payload_s;/* size of memory block */
-    h = 0;
+    const uint32_t h = 0;
 
     memset(&esp_hdr, 0, sizeof(esp_hdr));
     esp_hdr.esp_spi = htonl(spi);      /* SPI */
@@ -58,7 +57,11 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPSEC_ESP_HDR_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPSEC_ESP_HDR_H);
     if (p == NULL)
     {
         return (-1);
@@ -86,8 +89,7 @@ libnet_build_ipsec_esp_ftr(uint8_t len, uint8_t nh, int8_t *auth,
             libnet_ptag_t ptag)
 {
     /* XXX we need to know the size of auth */
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_esp_ftr esp_ftr;
 
     if (l == NULL)
@@ -96,7 +98,7 @@ libnet_build_ipsec_esp_ftr(uint8_t len, uint8_t nh, int8_t *auth,
     } 
 
     n = LIBNET_IPSEC_ESP_FTR_H + payload_s;/* size of memory block */
-    h = 0;
+    const uint32_t h = 0;
 
     memset(&esp_ftr, 0, sizeof(esp_ftr));
     esp_ftr.esp_pad_len = len;      /* pad length */
@@ -107,7 +109,11 @@ libnet_build_ipsec_esp_ftr(uint8_t len, uint8_t nh, int8_t *auth,
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPSEC_ESP_FTR_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPSEC_ESP_FTR_H);
     if (p == NULL)
     {
         return (-1);
@@ -135,8 +141,7 @@ libnet_build_ipsec_ah(uint8_t nh, uint8_t len, uint16_t res,
 uint32_t spi, uint32_t seq, uint32_t auth, const uint8_t *payload,
 uint32_t payload_s,  libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_ah_hdr ah_hdr;
 
     if (l == NULL)
@@ -145,13 +150,17 @@ uint32_t payload_s,  libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_IPSEC_AH_H + payload_s;/* size of memory block */
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_IPSEC_AH_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_IPSEC_AH_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_isl.c
+++ b/src/libnet_build_isl.c
@@ -33,13 +33,12 @@
 #include "common.h"
 
 libnet_ptag_t
-libnet_build_isl(uint8_t *dhost, uint8_t type, uint8_t user,
-uint8_t *shost, uint16_t len, const uint8_t *snap, uint16_t vid,
+libnet_build_isl(const uint8_t *dhost, uint8_t type, uint8_t user,
+const uint8_t *shost, uint16_t len, const uint8_t *snap, uint16_t vid,
 uint16_t portindex, uint16_t reserved, const uint8_t *payload,
 uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
     uint32_t n;
-    libnet_pblock_t *p;
     struct libnet_isl_hdr isl_hdr;
 
     if (l == NULL)
@@ -53,7 +52,11 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_ISL_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_ISL_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_link.c
+++ b/src/libnet_build_link.c
@@ -39,7 +39,7 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 
 {
     (void)oui; /* unused */
-    uint8_t org[3] = {0x00, 0x00, 0x00};
+    const uint8_t org[3] = {0x00, 0x00, 0x00};
     switch (l->link_type)
     {
         /* add FDDI */
@@ -61,7 +61,7 @@ libnet_ptag_t
 libnet_autobuild_link(const uint8_t *dst, const uint8_t *oui, uint16_t type, libnet_t *l)
 {
     (void)oui; /* unused */
-    uint8_t org[3] = {0x00, 0x00, 0x00};
+    const uint8_t org[3] = {0x00, 0x00, 0x00};
     switch (l->link_type)
     {
        /* add FDDI */

--- a/src/libnet_build_lldp.c
+++ b/src/libnet_build_lldp.c
@@ -1,16 +1,13 @@
 #include "common.h"
 
 LIBNET_API
-libnet_ptag_t libnet_build_lldp_chassis(const uint8_t subtype,
+libnet_ptag_t libnet_build_lldp_chassis(uint8_t subtype,
                                         const uint8_t *value,
-                                        const uint8_t value_s,
+                                        uint8_t value_s,
                                         libnet_t *l,
                                         libnet_ptag_t ptag)
 {
     struct libnet_lldp_hdr hdr = { 0 };
-    uint16_t type_and_len;
-    libnet_pblock_t *p;
-    uint32_t n, h;
 
     if (l == NULL)
         return (-1);
@@ -30,9 +27,10 @@ libnet_ptag_t libnet_build_lldp_chassis(const uint8_t subtype,
     }
 
     /* size of memory block */
-    n = h =  LIBNET_LLDP_TLV_HDR_SIZE + /* TLV Header size */
+    const uint32_t n = LIBNET_LLDP_TLV_HDR_SIZE + /* TLV Header size */
         LIBNET_LLDP_SUBTYPE_SIZE +      /* Chassis ID subtype size */
         value_s;                        /* Chassis ID string length */
+    const uint32_t h = n;
 
     LIBNET_LLDP_TLV_SET_TYPE(hdr.tlv_info, LIBNET_LLDP_CHASSIS_ID);
     LIBNET_LLDP_TLV_SET_LEN(hdr.tlv_info, value_s + LIBNET_LLDP_SUBTYPE_SIZE);
@@ -41,13 +39,17 @@ libnet_ptag_t libnet_build_lldp_chassis(const uint8_t subtype,
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LLDP_CHASSIS_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LLDP_CHASSIS_H);
     if (p == NULL)
     {
         return (-1);
     }
 
-    type_and_len = htons(hdr.tlv_info);
+    const uint16_t type_and_len = htons(hdr.tlv_info);
     if (libnet_pblock_append(l, p, &type_and_len, sizeof(type_and_len)) == -1)
         goto bad;
 
@@ -66,16 +68,13 @@ bad:
 
 
 LIBNET_API
-libnet_ptag_t libnet_build_lldp_port(const uint8_t subtype,
+libnet_ptag_t libnet_build_lldp_port(uint8_t subtype,
                                      const uint8_t *value,
-                                     const uint8_t value_s,
+                                     uint8_t value_s,
                                      libnet_t *l,
                                      libnet_ptag_t ptag)
 {
     struct libnet_lldp_hdr hdr = { 0 };
-    uint16_t type_and_len;
-    libnet_pblock_t *p;
-    uint32_t n, h;
 
     if (l == NULL)
         return (-1);
@@ -95,9 +94,10 @@ libnet_ptag_t libnet_build_lldp_port(const uint8_t subtype,
     }
 
     /* size of memory block */
-    n = h =  LIBNET_LLDP_TLV_HDR_SIZE + /* TLV Header size */
+    const uint32_t n = LIBNET_LLDP_TLV_HDR_SIZE + /* TLV Header size */
         LIBNET_LLDP_SUBTYPE_SIZE +      /* Port ID subtype size */
         value_s;                        /* Port ID string length */
+    const uint32_t h = n;
 
     LIBNET_LLDP_TLV_SET_TYPE(hdr.tlv_info, LIBNET_LLDP_PORT_ID);
     LIBNET_LLDP_TLV_SET_LEN(hdr.tlv_info, value_s + LIBNET_LLDP_SUBTYPE_SIZE);
@@ -106,11 +106,15 @@ libnet_ptag_t libnet_build_lldp_port(const uint8_t subtype,
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LLDP_PORT_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LLDP_PORT_H);
     if (p == NULL)
         return (-1);
 
-    type_and_len = htons(hdr.tlv_info);
+    const uint16_t type_and_len = htons(hdr.tlv_info);
     if (libnet_pblock_append(l, p, &type_and_len, sizeof(type_and_len)) == -1)
         goto bad;
 
@@ -130,14 +134,11 @@ bad:
 }
 
 LIBNET_API
-libnet_ptag_t libnet_build_lldp_ttl(const uint16_t ttl,
+libnet_ptag_t libnet_build_lldp_ttl(uint16_t ttl,
                                     libnet_t *l,
                                     libnet_ptag_t ptag)
 {
     struct libnet_lldp_hdr hdr = { 0 };
-    uint16_t type_and_len;
-    libnet_pblock_t *p;
-    uint32_t n, h;
 
     if (l == NULL)
         return (-1);
@@ -150,8 +151,9 @@ libnet_ptag_t libnet_build_lldp_ttl(const uint16_t ttl,
     }
 
     /* size of memory block */
-    n = h =  LIBNET_LLDP_TLV_HDR_SIZE + /* TLV Header size */
+    const uint32_t n = LIBNET_LLDP_TLV_HDR_SIZE + /* TLV Header size */
         sizeof(uint16_t);               /* Size of 2 octets */
+    const uint32_t h = n;
 
     LIBNET_LLDP_TLV_SET_TYPE(hdr.tlv_info, LIBNET_LLDP_TTL);
     LIBNET_LLDP_TLV_SET_LEN(hdr.tlv_info, sizeof(uint16_t)); /* Size is 2 octets */
@@ -160,11 +162,15 @@ libnet_ptag_t libnet_build_lldp_ttl(const uint16_t ttl,
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LLDP_TTL_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LLDP_TTL_H);
     if (p == NULL)
         return (-1);
 
-    type_and_len = htons(hdr.tlv_info);
+    const uint16_t type_and_len = htons(hdr.tlv_info);
     if (libnet_pblock_append(l, p, &type_and_len, sizeof(type_and_len)) == -1)
         goto bad;
 
@@ -185,15 +191,13 @@ LIBNET_API
 libnet_ptag_t libnet_build_lldp_end(libnet_t *l, libnet_ptag_t ptag)
 {
     struct libnet_lldp_hdr hdr = { 0 };
-    uint16_t type_and_len;
-    libnet_pblock_t *p;
-    uint32_t n, h;
 
     if (l == NULL)
         return (-1);
 
     /* size of memory block */
-    n = h =  LIBNET_LLDP_TLV_HDR_SIZE; /* TLV Header size */
+    const uint32_t n = LIBNET_LLDP_TLV_HDR_SIZE; /* TLV Header size */
+    const uint32_t h = n;
 
     LIBNET_LLDP_TLV_SET_TYPE(hdr.tlv_info, LIBNET_LLDP_END_LLDPDU);
     LIBNET_LLDP_TLV_SET_LEN(hdr.tlv_info, 0);
@@ -202,11 +206,15 @@ libnet_ptag_t libnet_build_lldp_end(libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LLDP_TTL_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LLDP_TTL_H);
     if (p == NULL)
         return (-1);
 
-    type_and_len = htons(hdr.tlv_info);
+    const uint16_t type_and_len = htons(hdr.tlv_info);
     if (libnet_pblock_append(l, p, &type_and_len, sizeof(type_and_len)) == -1)
         goto bad;
 
@@ -221,14 +229,11 @@ bad:
 
 LIBNET_API
 libnet_ptag_t libnet_build_lldp_org_spec(const uint8_t *value,
-                                         const uint16_t value_s,
+                                         uint16_t value_s,
                                          libnet_t *l,
                                          libnet_ptag_t ptag)
 {
     struct libnet_lldp_hdr hdr = { 0 };
-    uint16_t type_and_len;
-    libnet_pblock_t *p;
-    uint32_t n, h;
 
     if (l == NULL)
         return (-1);
@@ -251,18 +256,23 @@ libnet_ptag_t libnet_build_lldp_org_spec(const uint8_t *value,
     LIBNET_LLDP_TLV_SET_LEN(hdr.tlv_info, value_s);
 
     /* size of memory block */
-    n = h = LIBNET_LLDP_TLV_HDR_SIZE + /* TLV Header size */
+    const uint32_t n = LIBNET_LLDP_TLV_HDR_SIZE + /* TLV Header size */
         value_s;                       /* TLV Information length*/
+    const uint32_t h = n;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LLDP_ORG_SPEC_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LLDP_ORG_SPEC_H);
     if (p == NULL)
         return (-1);
 
-    type_and_len = htons(hdr.tlv_info);
+    const uint16_t type_and_len = htons(hdr.tlv_info);
     if (libnet_pblock_append(l, p, &type_and_len, sizeof(type_and_len)) == -1)
         goto bad;
 

--- a/src/libnet_build_mpls.c
+++ b/src/libnet_build_mpls.c
@@ -37,8 +37,7 @@ libnet_build_mpls(uint32_t label, uint8_t experimental, uint8_t bos,
 uint8_t ttl, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_mpls_hdr mpls_hdr;
 
     if (l == NULL)
@@ -47,13 +46,17 @@ libnet_ptag_t ptag)
     } 
 
     n = LIBNET_MPLS_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_MPLS_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_MPLS_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_ntp.c
+++ b/src/libnet_build_ntp.c
@@ -41,8 +41,7 @@ uint32_t orig_ts_int, uint32_t orig_ts_frac, uint32_t rec_ts_int,
 uint32_t rec_ts_frac, uint32_t xmt_ts_int, uint32_t xmt_ts_frac,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_ntp_hdr ntp_hdr;
 
     if (l == NULL)
@@ -51,13 +50,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_NTP_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_NTP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_NTP_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_ospf.c
+++ b/src/libnet_build_ospf.c
@@ -40,8 +40,7 @@ libnet_build_ospfv2(uint16_t len, uint8_t type, uint32_t rtr_id,
 uint32_t area_id, uint16_t sum, uint16_t autype, const uint8_t *payload, 
 uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_ospf_hdr ospf_hdr;
 
     if (l == NULL)
@@ -50,13 +49,17 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
  
     n = LIBNET_OSPF_H + payload_s;
-    h = LIBNET_OSPF_H + payload_s + len;
+    const uint32_t h = LIBNET_OSPF_H + payload_s + len;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_OSPF_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_OSPF_H);
     if (p == NULL)
     {
         return (-1);
@@ -110,8 +113,7 @@ libnet_build_ospfv2_hello_neighbor(uint32_t netmask, uint16_t interval, uint8_t 
 uint8_t priority, uint32_t dead_int, uint32_t des_rtr, uint32_t bkup_rtr, uint32_t neighbor,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_ospf_hello_hdr hello_hdr;
 
     if (l == NULL)
@@ -120,13 +122,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     }
 
     n = LIBNET_OSPF_HELLO_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_OSPF_HELLO_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_OSPF_HELLO_H);
     if (p == NULL)
     {
         return (-1);
@@ -162,8 +168,7 @@ libnet_build_ospfv2_dbd(uint16_t dgram_len, uint8_t opts, uint8_t type,
 uint32_t seqnum, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_dbd_hdr dbd_hdr;
 
     if (l == NULL)
@@ -172,13 +177,17 @@ libnet_ptag_t ptag)
     } 
 
     n = LIBNET_OSPF_DBD_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_OSPF_DBD_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_OSPF_DBD_H);
     if (p == NULL)
     {
         return (-1);
@@ -211,8 +220,7 @@ libnet_ptag_t
 libnet_build_ospfv2_lsr(uint32_t type, uint32_t lsid, uint32_t advrtr, 
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_lsr_hdr lsr_hdr;
 
     if (l == NULL)
@@ -221,13 +229,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_OSPF_LSR_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_OSPF_LSR_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_OSPF_LSR_H);
     if (p == NULL)
     {
         return (-1);
@@ -259,8 +271,7 @@ libnet_ptag_t
 libnet_build_ospfv2_lsu(uint32_t num, const uint8_t *payload, uint32_t payload_s,
 libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_lsu_hdr lh_hdr;
 
     if (l == NULL)
@@ -269,13 +280,17 @@ libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_OSPF_LSU_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_OSPF_LSU_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_OSPF_LSU_H);
     if (p == NULL)
     {
         return (-1);
@@ -305,8 +320,7 @@ libnet_build_ospfv2_lsa(uint16_t age, uint8_t opts, uint8_t type, uint32_t lsid,
 uint32_t advrtr, uint32_t seqnum, uint16_t sum, uint16_t len,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_lsa_hdr lsa_hdr;
 
     if (l == NULL)
@@ -315,13 +329,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_OSPF_LSA_H + payload_s;
-    h = len + payload_s;
+    const uint32_t h = len + payload_s;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_OSPF_LSA_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_OSPF_LSA_H);
     if (p == NULL)
     {
         return (-1);
@@ -368,8 +386,7 @@ libnet_build_ospfv2_lsa_rtr(uint16_t flags, uint16_t num, uint32_t id,
 uint32_t data, uint8_t type, uint8_t tos, uint16_t metric,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_rtr_lsa_hdr rtr_lsa_hdr;
 
     if (l == NULL)
@@ -378,13 +395,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_OSPF_LS_RTR_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LS_RTR_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LS_RTR_H);
     if (p == NULL)
     {
         return (-1);
@@ -420,8 +441,7 @@ libnet_ptag_t
 libnet_build_ospfv2_lsa_net(uint32_t nmask, uint32_t rtrid,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_net_lsa_hdr net_lsa_hdr;
 
     if (l == NULL)
@@ -430,13 +450,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_OSPF_LS_NET_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LS_NET_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LS_NET_H);
     if (p == NULL)
     {
         return (-1);
@@ -467,8 +491,7 @@ libnet_ptag_t
 libnet_build_ospfv2_lsa_sum(uint32_t nmask, uint32_t metric, uint32_t tos, 
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_sum_lsa_hdr sum_lsa_hdr;
 
     if (l == NULL)
@@ -477,13 +500,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_OSPF_LS_SUM_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LS_SUM_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LS_SUM_H);
     if (p == NULL)
     {
         return (-1);
@@ -516,8 +543,7 @@ libnet_build_ospfv2_lsa_as(uint32_t nmask, uint32_t metric, uint32_t fwdaddr,
 uint32_t tag, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_as_lsa_hdr as_lsa_hdr;
 
     if (l == NULL)
@@ -526,13 +552,17 @@ libnet_ptag_t ptag)
     } 
    
     n = LIBNET_OSPF_LS_AS_EXT_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_LS_AS_EXT_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_LS_AS_EXT_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_rip.c
+++ b/src/libnet_build_rip.c
@@ -38,8 +38,7 @@ uint16_t rt, uint32_t addr, uint32_t mask, uint32_t next_hop,
 uint32_t metric, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_rip_hdr rip_hdr;
 
     if (l == NULL)
@@ -48,13 +47,17 @@ libnet_ptag_t ptag)
     } 
 
     n = LIBNET_RIP_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_RIP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_RIP_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_rpc.c
+++ b/src/libnet_build_rpc.c
@@ -35,13 +35,12 @@
 libnet_ptag_t
 libnet_build_rpc_call(uint32_t rm, uint32_t xid, uint32_t prog_num, 
 uint32_t prog_vers, uint32_t procedure, uint32_t cflavor, uint32_t clength, 
-uint8_t *cdata, uint32_t vflavor, uint32_t vlength, const uint8_t *vdata, 
+const uint8_t *cdata, uint32_t vflavor, uint32_t vlength, const uint8_t *vdata, 
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
     (void)cdata; /* unused */
     (void)vdata; /* unused */
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_rpc_call_tcp_hdr rpc_hdr;
     int rc;
 
@@ -63,13 +62,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
         n = LIBNET_RPC_CALL_H + payload_s;
     }
  
-    h = 0;
+    const uint32_t h = 0;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_RPC_CALL_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_RPC_CALL_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_sebek.c
+++ b/src/libnet_build_sebek.c
@@ -34,11 +34,10 @@
 libnet_ptag_t
 libnet_build_sebek(uint32_t magic, uint16_t version, uint16_t type, 
 uint32_t counter, uint32_t time_sec, uint32_t time_usec, uint32_t pid,
-uint32_t uid, uint32_t fd, uint8_t cmd[SEBEK_CMD_LENGTH], uint32_t length,
+uint32_t uid, uint32_t fd, const uint8_t cmd[SEBEK_CMD_LENGTH], uint32_t length,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
     uint32_t n;
-    libnet_pblock_t *p;
     struct libnet_sebek_hdr sebek_hdr;
 
     if (l == NULL)
@@ -46,13 +45,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
         return (-1);
     } 
 
-    n = LIBNET_SEBEK_H + payload_s;               /* size of memory block */
+    n = LIBNET_SEBEK_H + payload_s;   /* size of memory block */
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_SEBEK_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_SEBEK_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_sebek.c
+++ b/src/libnet_build_sebek.c
@@ -45,7 +45,7 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
         return (-1);
     } 
 
-    n = LIBNET_SEBEK_H + payload_s;   /* size of memory block */
+    n = LIBNET_SEBEK_H + payload_s;               /* size of memory block */
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create

--- a/src/libnet_build_stp.c
+++ b/src/libnet_build_stp.c
@@ -39,14 +39,12 @@ uint16_t port_id, uint16_t message_age, uint16_t max_age,
 uint16_t hello_time, uint16_t f_delay, const uint8_t *payload,
 uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
 
     /* until we get some data marshalling in place we can't use this */
     /* struct libnet_stp_conf_hdr stp_hdr; */
     uint8_t stp_hdr[35];
     uint16_t value_s;
-    uint32_t value_l;
 
     if (l == NULL)
     { 
@@ -54,13 +52,17 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_STP_CONF_H + payload_s;          /* size of memory block */
-    h = 0;                                      /* no checksum */
+    const uint32_t h = 0;                       /* no checksum */
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_STP_CONF_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_STP_CONF_H);
     if (p == NULL)
     {
         return (-1);
@@ -88,7 +90,7 @@ uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     stp_hdr[3] = bpdu_type;
     stp_hdr[4] = flags;
     memcpy(&stp_hdr[5], root_id, 8);
-    value_l = htonl(root_pc);
+    const uint32_t value_l = htonl(root_pc);
     memcpy(&stp_hdr[13], &value_l, 4);
     memcpy(&stp_hdr[17], bridge_id, 8);
     value_s = htons(port_id);
@@ -141,8 +143,7 @@ libnet_ptag_t
 libnet_build_stp_tcn(uint16_t id, uint8_t version, uint8_t bpdu_type,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
 
     struct libnet_stp_tcn_hdr stp_hdr;
 
@@ -152,13 +153,17 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     } 
 
     n = LIBNET_STP_TCN_H + payload_s;           /* size of memory block */
-    h = 0;                                      /* no checksum */
+    const uint32_t h = 0;                       /* no checksum */
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_STP_TCN_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_STP_TCN_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_tcp.c
+++ b/src/libnet_build_tcp.c
@@ -39,7 +39,6 @@ libnet_build_tcp(
             const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
     int offset;
-    libnet_pblock_t *p = NULL;
     libnet_ptag_t ptag_data = 0;
     struct libnet_tcp_hdr tcp_hdr;
 
@@ -53,7 +52,11 @@ libnet_build_tcp(
         return -1;
     }
 
-    p = libnet_pblock_probe(l, ptag, LIBNET_TCP_H, LIBNET_PBLOCK_TCP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        LIBNET_TCP_H,
+        LIBNET_PBLOCK_TCP_H);
     if (p == NULL)
         return -1;
 
@@ -119,8 +122,8 @@ libnet_build_tcp(
 
         if(ipblock && ipblock->type == LIBNET_PBLOCK_IPV4_H)
         {
-            struct libnet_ipv4_hdr * ip_hdr = (struct libnet_ipv4_hdr *)ipblock->buf;
-            int ip_len = ntohs(ip_hdr->ip_len) + offset;
+            struct libnet_ipv4_hdr * const ip_hdr = (struct libnet_ipv4_hdr *)ipblock->buf;
+            const int ip_len = ntohs(ip_hdr->ip_len) + offset;
             ip_hdr->ip_len = htons(ip_len);
         }
     }
@@ -182,9 +185,7 @@ libnet_ptag_t ptag)
     static const uint8_t padding[] = { 0 };
     int offset, underflow;
     uint32_t i, j, adj_size;
-    libnet_pblock_t *p, *p_temp;
-    struct libnet_ipv4_hdr *ip_hdr;
-    struct libnet_tcp_hdr *tcp_hdr;
+    libnet_pblock_t *p_temp;
 
     if (l == NULL)
     { 
@@ -231,7 +232,11 @@ libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, adj_size, LIBNET_PBLOCK_TCPO_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        adj_size,
+        LIBNET_PBLOCK_TCPO_H);
     if (p == NULL)
     {
         return (-1);
@@ -264,7 +269,7 @@ libnet_ptag_t ptag)
             {
                 (i % 4) ? j : j++;
             }
-            tcp_hdr = (struct libnet_tcp_hdr *)p_temp->buf;
+            struct libnet_tcp_hdr * const tcp_hdr = (struct libnet_tcp_hdr *)p_temp->buf;
             tcp_hdr->th_off = j + 5;
             if (!underflow)
             {
@@ -281,7 +286,7 @@ libnet_ptag_t ptag)
         }
         if (p_temp->type == LIBNET_PBLOCK_IPV4_H)
         {
-            ip_hdr = (struct libnet_ipv4_hdr *)p_temp->buf;
+            struct libnet_ipv4_hdr * const ip_hdr = (struct libnet_ipv4_hdr *)p_temp->buf;
             if (!underflow)
             {
                 ip_hdr->ip_len += htons(offset);

--- a/src/libnet_build_token_ring.c
+++ b/src/libnet_build_token_ring.c
@@ -36,7 +36,7 @@ libnet_build_token_ring(uint8_t ac, uint8_t fc, const uint8_t *dst, const uint8_
 uint8_t dsap, uint8_t ssap, uint8_t cf, const uint8_t *org, uint16_t type,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
+    uint32_t n;
     libnet_pblock_t *p;
     struct libnet_token_ring_hdr token_ring_hdr;
 
@@ -57,7 +57,7 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     }
 
     n = LIBNET_TOKEN_RING_H + payload_s;
-    h = 0;
+    const uint32_t h = 0;
  
     /*
      *  Find the existing protocol block if a ptag is specified, or create
@@ -102,10 +102,7 @@ libnet_autobuild_token_ring(uint8_t ac, uint8_t fc, const uint8_t *dst,
 uint8_t dsap, uint8_t ssap, uint8_t cf, const uint8_t *org, uint16_t type, 
 libnet_t *l)
 {
-    uint32_t n, h;
-    struct libnet_token_ring_addr *src;
     libnet_pblock_t *p;
-    libnet_ptag_t ptag;
     struct libnet_token_ring_hdr token_ring_hdr;
 
     if (l == NULL)
@@ -124,12 +121,13 @@ libnet_t *l)
         goto bad;
     }
 
-    n = LIBNET_TOKEN_RING_H;
-    h = 0;
-    ptag = LIBNET_PTAG_INITIALIZER;
+    const uint32_t n = LIBNET_TOKEN_RING_H;
+    const uint32_t h = 0;
+    const libnet_ptag_t ptag = LIBNET_PTAG_INITIALIZER;
 
     /* Token Ring and Ethernet have the same address size - so just typecast */
-    src = (struct libnet_token_ring_addr *) libnet_get_hwaddr(l);
+    struct libnet_token_ring_addr *
+        const src = (struct libnet_token_ring_addr *) libnet_get_hwaddr(l);
     if (src == NULL)
     {
         /* err msg set in libnet_get_hwaddr() */

--- a/src/libnet_build_udld.c
+++ b/src/libnet_build_udld.c
@@ -3,22 +3,21 @@
 #include <assert.h>
 
 static libnet_ptag_t
-internal_build_udld_tlv(const uint16_t tlv_type, const uint8_t *value,
-const uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
+internal_build_udld_tlv(uint16_t tlv_type, const uint8_t *value,
+uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
 {
     struct libnet_udld_hdr hdr;
-    uint32_t n, h;
-    libnet_pblock_t *p;
 
     hdr.tlv__type   = tlv_type;
     hdr.tlv__length = LIBNET_UDLD_TLV_HDR_SIZE + value_s;
 
-    uint32_t host_type_and_len    = 0;
-    host_type_and_len             |= (hdr.tlv__type << 16);
-    host_type_and_len             |= (hdr.tlv__length);
-    uint32_t network_type_and_len = htonl(host_type_and_len);
+    const uint32_t host_type_and_len = 0
+        | (hdr.tlv__type << 16)
+        | (hdr.tlv__length);
+    const uint32_t network_type_and_len = htonl(host_type_and_len);
 
-    n = h = LIBNET_UDLD_TLV_HDR_SIZE + value_s;
+    const uint32_t n = LIBNET_UDLD_TLV_HDR_SIZE + value_s;
+    const uint32_t h = n;
 
     uint8_t pblock_type = 0;
     uint8_t value_type  = 0;
@@ -62,7 +61,7 @@ const uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, pblock_type);
+    libnet_pblock_t * const p = libnet_pblock_probe(l, ptag, n, pblock_type);
     if (p == NULL)
     {
         return (-1);
@@ -126,9 +125,8 @@ const uint8_t *payload, uint32_t payload_s, libnet_t * l, libnet_ptag_t ptag)
 {
 
     struct libnet_udld_hdr udld_hdr;
-    libnet_pblock_t *p = NULL;
     uint32_t n = 0;
-    uint32_t h = 0;
+    const uint32_t h = 0;
 
     if (l == NULL)
     {
@@ -141,7 +139,11 @@ const uint8_t *payload, uint32_t payload_s, libnet_t * l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_UDLD_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_UDLD_H);
     if (p == NULL)
     {
         return (-1);
@@ -181,7 +183,7 @@ const uint8_t *payload, uint32_t payload_s, libnet_t * l, libnet_ptag_t ptag)
 }
 
 LIBNET_API libnet_ptag_t
-libnet_build_udld_device_id(const uint8_t *value, const uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
+libnet_build_udld_device_id(const uint8_t *value, uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
 {
     if (l == NULL)
     {
@@ -198,7 +200,7 @@ libnet_build_udld_device_id(const uint8_t *value, const uint8_t value_s, libnet_
 }
 
 LIBNET_API libnet_ptag_t
-libnet_build_udld_port_id(const uint8_t *value, const uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
+libnet_build_udld_port_id(const uint8_t *value, uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
 {
     if (l == NULL)
     {
@@ -215,7 +217,7 @@ libnet_build_udld_port_id(const uint8_t *value, const uint8_t value_s, libnet_t 
 }
 
 LIBNET_API libnet_ptag_t
-libnet_build_udld_echo(const uint8_t *value, const uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
+libnet_build_udld_echo(const uint8_t *value, uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
 {
     if (l == NULL)
     {
@@ -270,7 +272,7 @@ libnet_ptag_t ptag)
 }
 
 LIBNET_API libnet_ptag_t
-libnet_build_udld_device_name(const uint8_t *value, const uint8_t value_s,
+libnet_build_udld_device_name(const uint8_t *value, uint8_t value_s,
 libnet_t *l, libnet_ptag_t ptag)
 {
     if (l == NULL)

--- a/src/libnet_build_udld.c
+++ b/src/libnet_build_udld.c
@@ -7,6 +7,7 @@ internal_build_udld_tlv(uint16_t tlv_type, const uint8_t *value,
 uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
 {
     struct libnet_udld_hdr hdr;
+    libnet_pblock_t *p;
 
     hdr.tlv__type   = tlv_type;
     hdr.tlv__length = LIBNET_UDLD_TLV_HDR_SIZE + value_s;
@@ -54,6 +55,7 @@ uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
         default:
             snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
             "%s(): incorrect TLV type", __func__);
+            p = NULL;
             goto bad;
     }
 
@@ -61,7 +63,7 @@ uint8_t value_s, libnet_t * l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    libnet_pblock_t * const p = libnet_pblock_probe(l, ptag, n, pblock_type);
+    p = libnet_pblock_probe(l, ptag, n, pblock_type);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_udp.c
+++ b/src/libnet_build_udp.c
@@ -37,7 +37,6 @@ libnet_build_udp(uint16_t sp, uint16_t dp, uint16_t len, uint16_t sum,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
     uint32_t n;
-    libnet_pblock_t *p;
     struct libnet_udp_hdr udp_hdr;
 
     if (l == NULL)
@@ -51,7 +50,11 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_UDP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_UDP_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_build_vrrp.c
+++ b/src/libnet_build_vrrp.c
@@ -38,8 +38,7 @@ uint8_t priority, uint8_t ip_count, uint8_t auth_type, uint8_t advert_int,
 uint16_t sum, const uint8_t *payload, uint32_t payload_s, libnet_t *l,
 libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
+    uint32_t n;
     struct libnet_vrrp_hdr vrrp_hdr;
 
     if (l == NULL)
@@ -48,13 +47,17 @@ libnet_ptag_t ptag)
     } 
 
     n = LIBNET_VRRP_H + payload_s;
-    h = LIBNET_VRRP_H + payload_s;
+    const uint32_t h = LIBNET_VRRP_H + payload_s;
 
     /*
      *  Find the existing protocol block if a ptag is specified, or create
      *  a new one.
      */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_VRRP_H);
+    libnet_pblock_t * const p = libnet_pblock_probe(
+        l,
+        ptag,
+        n,
+        LIBNET_PBLOCK_VRRP_H);
     if (p == NULL)
     {
         return (-1);

--- a/src/libnet_checksum.c
+++ b/src/libnet_checksum.c
@@ -34,7 +34,7 @@
 
 /* Note: len is in bytes, not 16-bit words! */
 int
-libnet_in_cksum(uint16_t *addr, int len)
+libnet_in_cksum(const uint16_t *addr, int len)
 {
     int sum = 0;
     union
@@ -64,9 +64,7 @@ libnet_in_cksum(uint16_t *addr, int len)
 int
 libnet_toggle_checksum(libnet_t *l, libnet_ptag_t ptag, int mode)
 {
-    libnet_pblock_t *p;
-
-    p = libnet_pblock_find(l, ptag);
+    libnet_pblock_t * const p = libnet_pblock_find(l, ptag);
     if (p == NULL)
     {
         /* err msg set in libnet_pblock_find() */
@@ -123,8 +121,8 @@ int
 libnet_do_checksum(libnet_t *l, uint8_t *iphdr, int protocol, int h_len)
 {
     uint16_t ip_len = 0;
-    struct libnet_ipv4_hdr* ip4 = (struct libnet_ipv4_hdr *)iphdr;
-    struct libnet_ipv6_hdr* ip6 = (struct libnet_ipv6_hdr *)iphdr;
+    struct libnet_ipv4_hdr* const ip4 = (struct libnet_ipv4_hdr *)iphdr;
+    struct libnet_ipv6_hdr* const ip6 = (struct libnet_ipv6_hdr *)iphdr;
 
     if(ip4->ip_v == 6) {
         ip_len = ntohs(ip6->ip_len);
@@ -564,7 +562,7 @@ libnet_inet_checksum(libnet_t *l, uint8_t *iphdr, int protocol, int h_len, const
 
 
 uint16_t
-libnet_ip_check(uint16_t *addr, int len)
+libnet_ip_check(const uint16_t *addr, int len)
 {
     int sum;
 

--- a/src/libnet_cq.c
+++ b/src/libnet_cq.c
@@ -5,7 +5,7 @@
  *  libnet_cq.c - context queue management routines
  *
  *  Copyright (c) 1998 - 2004 Mike D. Schiffman <mike@infonexus.com>
- *  Copyright (c) 2002 Fr�d�ric Raynal <pappy@security-labs.org>
+ *  Copyright (c) 2002 Frédéric Raynal <pappy@security-labs.org>
  *  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/libnet_cq.c
+++ b/src/libnet_cq.c
@@ -5,7 +5,7 @@
  *  libnet_cq.c - context queue management routines
  *
  *  Copyright (c) 1998 - 2004 Mike D. Schiffman <mike@infonexus.com>
- *  Copyright (c) 2002 Frédéric Raynal <pappy@security-labs.org>
+ *  Copyright (c) 2002 Frï¿½dï¿½ric Raynal <pappy@security-labs.org>
  *  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,9 +34,9 @@
 #include "common.h"
 
 /* private function prototypes */
-static libnet_cq_t *libnet_cq_find_internal(libnet_t *);
-static int libnet_cq_dup_check(libnet_t *, char *);
-static libnet_cq_t *libnet_cq_find_by_label_internal(char *label);
+static libnet_cq_t *libnet_cq_find_internal(const libnet_t *);
+static int libnet_cq_dup_check(libnet_t *, const char *);
+static libnet_cq_t *libnet_cq_find_by_label_internal(const char *label);
 
 /* global context queue */
 static libnet_cq_t *l_cq = NULL;
@@ -68,10 +68,8 @@ clear_cq_lock(uint32_t x)
 }
 
 int 
-libnet_cq_add(libnet_t *l, char *label)
+libnet_cq_add(libnet_t *l, const char *label)
 {
-    libnet_cq_t *new_cq;
-
     if (l == NULL) 
     {
         return (-1);
@@ -127,7 +125,7 @@ libnet_cq_add(libnet_t *l, char *label)
         return (-1);
     }
 
-    new_cq = (libnet_cq_t *)malloc(sizeof (libnet_cq_t));
+    libnet_cq_t * const new_cq = (libnet_cq_t *)malloc(sizeof (libnet_cq_t));
     if (new_cq == NULL)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
@@ -157,9 +155,6 @@ libnet_cq_add(libnet_t *l, char *label)
 libnet_t *
 libnet_cq_remove(libnet_t *l) 
 {
-    libnet_cq_t *p;
-    libnet_t *ret;
-
     if (l_cq == NULL) 
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
@@ -180,8 +175,9 @@ libnet_cq_remove(libnet_t *l)
                 __func__);
         return (NULL);
     }
-  
-    if ((p = libnet_cq_find_internal(l)) == NULL)
+
+    libnet_cq_t * const p = libnet_cq_find_internal(l);
+    if (p == NULL)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                 "%s(): context not present in context queue", __func__);
@@ -201,7 +197,7 @@ libnet_cq_remove(libnet_t *l)
         p->next->prev = p->prev;
     }
 
-    ret = p->context;
+    libnet_t * const ret = p->context;
     free(p);
 
     /* track the number of nodes in the cq */
@@ -211,12 +207,10 @@ libnet_cq_remove(libnet_t *l)
 }
 
 libnet_t *
-libnet_cq_remove_by_label(char *label) 
+libnet_cq_remove_by_label(const char *label) 
 {
-    libnet_cq_t *p;
-    libnet_t *ret;
-
-    if ((p = libnet_cq_find_by_label_internal(label)) == NULL)
+    libnet_cq_t * const p = libnet_cq_find_by_label_internal(label);
+    if (p == NULL)
     {
         /* no context to write an error message */
         return (NULL);
@@ -241,7 +235,7 @@ libnet_cq_remove_by_label(char *label)
         p->next->prev = p->prev;
     }
 
-    ret = p->context;
+    libnet_t * const ret = p->context;
     free(p);
 
     /* track the number of nodes in the cq */
@@ -251,7 +245,7 @@ libnet_cq_remove_by_label(char *label)
 }
 
 libnet_cq_t *
-libnet_cq_find_internal(libnet_t *l) 
+libnet_cq_find_internal(const libnet_t *l) 
 {
     libnet_cq_t *p;
 
@@ -266,7 +260,7 @@ libnet_cq_find_internal(libnet_t *l)
 }
 
 int
-libnet_cq_dup_check(libnet_t *l, char *label)
+libnet_cq_dup_check(libnet_t *l, const char *label)
 {
     libnet_cq_t *p;
 
@@ -290,7 +284,7 @@ libnet_cq_dup_check(libnet_t *l, char *label)
 }
 
 libnet_cq_t *
-libnet_cq_find_by_label_internal(char *label) 
+libnet_cq_find_by_label_internal(const char *label) 
 {
     libnet_cq_t *p;
   
@@ -310,16 +304,14 @@ libnet_cq_find_by_label_internal(char *label)
 }
 
 libnet_t *
-libnet_cq_find_by_label(char *label)
+libnet_cq_find_by_label(const char *label)
 {
-    libnet_cq_t *p;
-  
-    p = libnet_cq_find_by_label_internal(label);
+    libnet_cq_t * const p = libnet_cq_find_by_label_internal(label);
     return (p ? p->context : NULL);
 }
 
 const char *
-libnet_cq_getlabel(libnet_t *l)
+libnet_cq_getlabel(const libnet_t *l)
 {
     return (l->label);
 }

--- a/src/libnet_crc.c
+++ b/src/libnet_crc.c
@@ -88,7 +88,7 @@ static uint32_t crc_table[256] =
  *      n = 32, 26, 23, 22, 16, 12, 11, 10, 8, 7, 5, 4, 2, 1, 0
  */
 uint32_t
-libnet_compute_crc(uint8_t *buf, uint32_t len)
+libnet_compute_crc(const uint8_t *buf, uint32_t len)
 {
     uint32_t val;
 

--- a/src/libnet_error.c
+++ b/src/libnet_error.c
@@ -33,7 +33,7 @@
 #include "common.h"
 
 char *
-libnet_geterror(libnet_t *l)
+libnet_geterror(const libnet_t *l)
 {
     if (l == NULL)
     { 

--- a/src/libnet_error.c
+++ b/src/libnet_error.c
@@ -33,7 +33,7 @@
 #include "common.h"
 
 char *
-libnet_geterror(const libnet_t *l)
+libnet_geterror(libnet_t *l)
 {
     if (l == NULL)
     { 

--- a/src/libnet_if_addr.c
+++ b/src/libnet_if_addr.c
@@ -73,9 +73,9 @@ int
 libnet_check_iface(libnet_t *l)
 {
     struct ifreq ifr;
-    int fd, res;
+    int res;
 
-    fd = socket(AF_INET, SOCK_DGRAM, 0);
+    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE, "%s() socket: %s", __func__, strerror(errno));
@@ -113,7 +113,7 @@ libnet_check_iface(libnet_t *l)
 #include <ifaddrs.h>
 
 int
-libnet_ifaddrlist(struct libnet_ifaddr_list **ipaddrp, char *dev, char *errbuf)
+libnet_ifaddrlist(struct libnet_ifaddr_list **ipaddrp, const char *dev, char *errbuf)
 {
     struct libnet_ifaddr_list *ifaddrlist = NULL;
     struct ifaddrs *ifap, *ifa;
@@ -185,24 +185,22 @@ libnet_ifaddrlist(struct libnet_ifaddr_list **ipaddrp, char *dev, char *errbuf)
 #endif
 
 int
-libnet_ifaddrlist(struct libnet_ifaddr_list **ipaddrp, char *dev, char *errbuf)
+libnet_ifaddrlist(struct libnet_ifaddr_list **ipaddrp, const char *dev, char *errbuf)
 {
     struct libnet_ifaddr_list *ifaddrlist = NULL;
     struct ifreq ibuf[MAX_IPADDR];
     size_t nipaddr = 0;
     struct ifconf ifc;
     char buf[BUFSIZE];
-    FILE *fp;
-    int fd;
 
-    fd = socket(AF_INET, SOCK_DGRAM, 0);
+    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0)
     {
 	snprintf(errbuf, LIBNET_ERRBUF_SIZE, "%s(): socket error: %s", __func__, strerror(errno));
 	return (-1);
     }
 
-    fp = fopen(PROC_DEV_FILE, "r");
+    FILE * const fp = fopen(PROC_DEV_FILE, "r");
     if (!fp)
     {
 	snprintf(errbuf, LIBNET_ERRBUF_SIZE, "%s(): failed opening %s: %s",  __func__, PROC_DEV_FILE, strerror(errno));
@@ -317,16 +315,15 @@ bad:
 #endif
 
 int
-libnet_ifaddrlist(struct libnet_ifaddr_list **ipaddrp, char *dev, char *errbuf)
+libnet_ifaddrlist(struct libnet_ifaddr_list **ipaddrp, const char *dev, char *errbuf)
 {
     struct libnet_ifaddr_list *ifaddrlist = NULL;
-    struct ifreq *ifr, *lifr, *pifr, nifr;
+    struct ifreq *ifr, *pifr, nifr;
     struct ifreq ibuf[MAX_IPADDR];
     size_t nipaddr = 0;
     struct ifconf ifc;
-    int fd;
 
-    fd = socket(AF_INET, SOCK_DGRAM, 0);
+    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0)
     {
 	snprintf(errbuf, LIBNET_ERRBUF_SIZE, "%s(): socket error: %s", __func__, strerror(errno));
@@ -344,7 +341,7 @@ libnet_ifaddrlist(struct libnet_ifaddr_list **ipaddrp, char *dev, char *errbuf)
     }
 
     pifr = NULL;
-    lifr = (struct ifreq *)&ifc.ifc_buf[ifc.ifc_len];
+    struct ifreq * const lifr = (struct ifreq *)&ifc.ifc_buf[ifc.ifc_len];
 
     ifaddrlist = calloc(ip_addr_num, sizeof(struct libnet_ifaddr_list));
     if (!ifaddrlist)
@@ -449,9 +446,8 @@ static int8_t *iptos(uint32_t in)
 {
     static int8_t output[IPTOSBUFFERS][ 3 * 4 + 3 + 1];
     static int16_t which;
-    uint8_t *p;
 
-    p = (uint8_t *)&in;
+    uint8_t * const p = (uint8_t *)&in;
     which = (which + 1 == IPTOSBUFFERS ? 0 : which + 1);
     snprintf(output[which], IPTOSBUFFERS, "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
 
@@ -547,8 +543,7 @@ int
 libnet_select_device(libnet_t *l)
 {
     struct libnet_ifaddr_list *address_list = NULL, *al;
-    uint32_t addr;
-    int c, i, rc;
+    int i, rc;
 
     if (l == NULL)
     { 
@@ -570,7 +565,7 @@ libnet_select_device(libnet_t *l)
     /*
      *  Number of interfaces.
      */
-    c = libnet_ifaddrlist(&address_list, l->device, l->err_buf);
+    const int c = libnet_ifaddrlist(&address_list, l->device, l->err_buf);
     if (c < 0)
     {
         goto end;
@@ -584,7 +579,7 @@ libnet_select_device(libnet_t *l)
     al = address_list;
     if (l->device)
     {
-        addr = libnet_name2addr4(l, l->device, LIBNET_DONT_RESOLVE);
+        const uint32_t addr = libnet_name2addr4(l, l->device, LIBNET_DONT_RESOLVE);
 
         for (i = c; i; --i, ++al)
         {

--- a/src/libnet_init.c
+++ b/src/libnet_init.c
@@ -35,6 +35,8 @@
 libnet_t *
 libnet_init(int injection_type, const char *device, char *err_buf)
 {
+    libnet_t *l = NULL;
+
 #if defined(__WIN32__)
     WSADATA wsaData;
 
@@ -46,7 +48,7 @@ libnet_init(int injection_type, const char *device, char *err_buf)
     }
 #endif
 
-    libnet_t * const l = (libnet_t *)malloc(sizeof (libnet_t));
+    l = (libnet_t *)malloc(sizeof (libnet_t));
     if (l == NULL)
     {
         snprintf(err_buf, LIBNET_ERRBUF_SIZE, "%s(): malloc(): %s", __func__,

--- a/src/libnet_init.c
+++ b/src/libnet_init.c
@@ -35,8 +35,6 @@
 libnet_t *
 libnet_init(int injection_type, const char *device, char *err_buf)
 {
-    libnet_t *l = NULL;
-
 #if defined(__WIN32__)
     WSADATA wsaData;
 
@@ -48,7 +46,7 @@ libnet_init(int injection_type, const char *device, char *err_buf)
     }
 #endif
 
-    l = (libnet_t *)malloc(sizeof (libnet_t));
+    libnet_t * const l = (libnet_t *)malloc(sizeof (libnet_t));
     if (l == NULL)
     {
         snprintf(err_buf, LIBNET_ERRBUF_SIZE, "%s(): malloc(): %s", __func__,
@@ -150,7 +148,7 @@ libnet_clear_packet(libnet_t *l)
 }
 
 void
-libnet_stats(libnet_t *l, struct libnet_stats *ls)
+libnet_stats(const libnet_t *l, struct libnet_stats *ls)
 {
     if (l == NULL)
     { 
@@ -163,7 +161,7 @@ libnet_stats(libnet_t *l, struct libnet_stats *ls)
 }
 
 int
-libnet_getfd(libnet_t *l)
+libnet_getfd(const libnet_t *l)
 {
     if (l == NULL)
     { 
@@ -194,7 +192,7 @@ libnet_setfd_max_sndbuf(libnet_t *l, int max_bytes)
 #endif /* SO_SNDBUF */
 
 const char *
-libnet_getdevice(libnet_t *l)
+libnet_getdevice(const libnet_t *l)
 {
     if (l == NULL)
     { 
@@ -207,14 +205,12 @@ libnet_getdevice(libnet_t *l)
 uint8_t *
 libnet_getpbuf(libnet_t *l, libnet_ptag_t ptag)
 {
-    libnet_pblock_t *p;
-
     if (l == NULL)
     { 
         return (NULL);
     }
 
-    p = libnet_pblock_find(l, ptag);
+    libnet_pblock_t * const p = libnet_pblock_find(l, ptag);
     if (p == NULL)
     {
         /* err msg set in libnet_pblock_find() */
@@ -229,14 +225,12 @@ libnet_getpbuf(libnet_t *l, libnet_ptag_t ptag)
 uint32_t
 libnet_getpbuf_size(libnet_t *l, libnet_ptag_t ptag)
 {
-    libnet_pblock_t *p;
-
     if (l == NULL)
     { 
         return (0);
     } 
 
-    p = libnet_pblock_find(l, ptag);
+    libnet_pblock_t * const p = libnet_pblock_find(l, ptag);
     if (p == NULL)
     {
         /* err msg set in libnet_pblock_find() */
@@ -249,7 +243,7 @@ libnet_getpbuf_size(libnet_t *l, libnet_ptag_t ptag)
 }
 
 uint32_t
-libnet_getpacket_size(libnet_t *l)
+libnet_getpacket_size(const libnet_t *l)
 {
     /* Why doesn't this return l->total_size? */
     libnet_pblock_t *p;

--- a/src/libnet_internal.c
+++ b/src/libnet_internal.c
@@ -67,7 +67,7 @@ libnet_diag_dump_hex(const uint8_t *packet, uint32_t len, int swap, FILE *stream
 
 
 void
-libnet_diag_dump_context(libnet_t *l)
+libnet_diag_dump_context(const libnet_t *l)
 {
     if (l == NULL)
     { 
@@ -118,10 +118,10 @@ libnet_diag_dump_context(libnet_t *l)
 }
 
 void
-libnet_diag_dump_pblock(libnet_t *l)
+libnet_diag_dump_pblock(const libnet_t *l)
 {
     uint32_t n;
-    libnet_pblock_t *p;
+    const libnet_pblock_t *p;
 
     for (p = l->protocol_blocks; p; p = p->next)
     {

--- a/src/libnet_link_bpf.c
+++ b/src/libnet_link_bpf.c
@@ -226,7 +226,7 @@ bad:
 
 
 int
-libnet_close_link(libnet_t *l)
+libnet_close_link(const libnet_t *l)
 {
     if (close(l->fd) == 0)
     {
@@ -242,14 +242,12 @@ libnet_close_link(libnet_t *l)
 int
 libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
 {
-    int c;
-
     if (l == NULL)
     { 
         return (-1);
     } 
 
-    c = write(l->fd, packet, size);
+    const int c = write(l->fd, packet, size);
     if (c != size)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
@@ -264,9 +262,8 @@ libnet_get_hwaddr(libnet_t *l)
 {
     int mib[6];
     size_t len;
-    int8_t *buf, *next, *end;
+    int8_t *next;
     struct if_msghdr *ifm;
-    struct sockaddr_dl *sdl;
 
     mib[0] = CTL_NET;
     mib[1] = AF_ROUTE;
@@ -296,7 +293,7 @@ libnet_get_hwaddr(libnet_t *l)
         return (NULL);
     }
 
-    buf = (int8_t *)malloc(len);
+    int8_t * const buf = (int8_t *)malloc(len);
     if (buf == NULL)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE, "%s(): malloc(): %s",
@@ -310,7 +307,7 @@ libnet_get_hwaddr(libnet_t *l)
         free(buf);
         return (NULL);
     }
-    end = buf + len;
+    int8_t * const end = buf + len;
 
     for (next = buf ; next < end ; next += ifm->ifm_msglen)
     {
@@ -321,7 +318,7 @@ libnet_get_hwaddr(libnet_t *l)
 
         if (ifm->ifm_type == RTM_IFINFO)
         {
-            sdl = (struct sockaddr_dl *)(ifm + 1);
+            struct sockaddr_dl * const sdl = (struct sockaddr_dl *)(ifm + 1);
             if (sdl->sdl_type != IFT_ETHER
 #ifdef IFT_FASTETHER
                 && sdl->sdl_type != IFT_FASTETHER

--- a/src/libnet_link_bpf.c
+++ b/src/libnet_link_bpf.c
@@ -226,7 +226,7 @@ bad:
 
 
 int
-libnet_close_link(const libnet_t *l)
+libnet_close_link(libnet_t *l)
 {
     if (close(l->fd) == 0)
     {

--- a/src/libnet_link_dlpi.c
+++ b/src/libnet_link_dlpi.c
@@ -700,7 +700,7 @@ struct  EnetHeaderInfo
 
 
 int
-libnet_close_link(const libnet_t *l)
+libnet_close_link(libnet_t *l)
 {
     if (close(l->fd) == 0)
     {

--- a/src/libnet_link_dlpi.c
+++ b/src/libnet_link_dlpi.c
@@ -102,7 +102,7 @@ static int dlinfoack(int, int8_t *, int8_t *);
 static int dlinforeq(int, int8_t *);
 static int dlokack(int, const int8_t *, int8_t *, int8_t *);
 static int recv_ack(int, int, const int8_t *, int8_t *, int8_t *);
-static int send_request(int, int8_t *, int, int8_t *, int8_t *, int);
+static int send_request(int, int8_t *, int, const int8_t *, int8_t *, int);
 #ifdef HAVE_SYS_BUFMOD_H
 static int strioctl(int, int, int, int8_t *);
 #endif
@@ -118,7 +118,7 @@ static bpf_u_int32 ctlbuf[MAXDLBUF];
 
 /* Return a pointer to the last character in 'in' that is not in 's',
  * or NULL if no such character exists. */
-static char *find_last_not_of(char *in, const char *s)
+static char *find_last_not_of(const char *in, const char *s)
 {
   char* cur;
   cur = in + strlen(in);
@@ -202,7 +202,6 @@ try_open_dev(libnet_t *l, const char *dev, int unit)
 int
 libnet_open_link(libnet_t *l)
 {
-    int8_t *cp;
     int8_t *eos;
     int ppa;
     dl_info_ack_t *infop;
@@ -242,7 +241,7 @@ libnet_open_link(libnet_t *l)
     /*
      *  Map network device to /dev/dlpi unit
      */
-    cp = "/dev/dlpi";
+    int8_t * const cp = "/dev/dlpi";
 
     l->fd = open(cp, O_RDWR);
     if (l->fd == -1)
@@ -349,7 +348,7 @@ bad:
 
 
 static int
-send_request(int fd, int8_t *ptr, int len, int8_t *what, int8_t *ebuf, int flags)
+send_request(int fd, int8_t *ptr, int len, const int8_t *what, int8_t *ebuf, int flags)
 {
     struct strbuf ctl;
 
@@ -370,7 +369,6 @@ send_request(int fd, int8_t *ptr, int len, int8_t *what, int8_t *ebuf, int flags
 static int
 recv_ack(int fd, int size, const int8_t *what, int8_t *bufp, int8_t *ebuf)
 {
-    union DL_primitives *dlp;
     struct strbuf ctl;
     int flags;
 
@@ -386,7 +384,7 @@ recv_ack(int fd, int size, const int8_t *what, int8_t *bufp, int8_t *ebuf)
         return (-1);
     }
 
-    dlp = (union DL_primitives *)ctl.buf;
+    union DL_primitives * const dlp = (union DL_primitives *)ctl.buf;
     switch (dlp->dl_primitive)
     {
         case DL_INFO_ACK:
@@ -512,14 +510,13 @@ static int
 strioctl(int fd, int cmd, int len, int8_t *dp)
 {
     struct strioctl str;
-    int rc;
 
     str.ic_cmd    = cmd;
     str.ic_timout = -1;
     str.ic_len    = len;
     str.ic_dp     = dp;
     
-    rc = ioctl(fd, I_STR, &str);
+    const int rc = ioctl(fd, I_STR, &str);
     if (rc < 0)
     {
         return (rc);
@@ -539,10 +536,8 @@ strioctl(int fd, int cmd, int len, int8_t *dp)
 static int
 get_dlpi_ppa(int fd, const int8_t *device, int unit, int8_t *ebuf)
 {
-    dl_hp_ppa_ack_t *ap;
     dl_hp_ppa_info_t *ip;
     int i;
-    uint32_t majdev;
     dl_hp_ppa_req_t	req;
     struct stat statbuf;
     bpf_u_int32 buf[MAXDLBUF];
@@ -553,7 +548,7 @@ get_dlpi_ppa(int fd, const int8_t *device, int unit, int8_t *ebuf)
                  "stat: %s: %s", device, strerror(errno));
         return (-1);
     }
-    majdev = major(statbuf.st_rdev);
+    const uint32_t majdev = major(statbuf.st_rdev);
 
     memset((int8_t *)&req, 0, sizeof(req));
     req.dl_primitive = DL_HP_PPA_REQ;
@@ -565,7 +560,7 @@ get_dlpi_ppa(int fd, const int8_t *device, int unit, int8_t *ebuf)
         return (-1);
     }
 
-    ap = (dl_hp_ppa_ack_t *)buf;
+    dl_hp_ppa_ack_t * const ap = (dl_hp_ppa_ack_t *)buf;
     ip = (dl_hp_ppa_info_t *)((uint8_t *)ap + ap->dl_offset);
 
     for (i = 0; i < ap->dl_count; i++)
@@ -613,13 +608,11 @@ static int8_t path_vmunix[] = "/hp-ux";
 static int
 get_dlpi_ppa(int fd, const int8_t *ifname, int unit, int8_t *ebuf)
 {
-    const int8_t *cp;
-    int kd;
     void *addr;
     struct ifnet ifnet;
     int8_t if_name[sizeof(ifnet.if_name)], tifname[32];
 
-    cp = strrchr(ifname, '/');
+    const int8_t * const cp = strrchr(ifname, '/');
     if (cp != NULL)
     {
         ifname = cp + 1;
@@ -638,7 +631,7 @@ get_dlpi_ppa(int fd, const int8_t *ifname, int unit, int8_t *ebuf)
         return (-1);
     }
 
-    kd = open("/dev/kmem", O_RDONLY);
+    const int kd = open("/dev/kmem", O_RDONLY);
     if (kd < 0)
     {
         snprintf(ebuf, LIBNET_ERRBUF_SIZE,
@@ -675,15 +668,13 @@ get_dlpi_ppa(int fd, const int8_t *ifname, int unit, int8_t *ebuf)
 static int
 dlpi_kread(int fd, off_t addr, void *buf, uint len, int8_t *ebuf)
 {
-    int cc;
-
     if (lseek(fd, addr, SEEK_SET) < 0)
     {
         snprintf(ebuf, LIBNET_ERRBUF_SIZE,
                  "lseek: %s", strerror(errno));
         return (-1);
     }
-    cc = read(fd, buf, len);
+    const int cc = read(fd, buf, len);
     if (cc < 0)
     {
         snprintf(ebuf, LIBNET_ERRBUF_SIZE,
@@ -709,7 +700,7 @@ struct  EnetHeaderInfo
 
 
 int
-libnet_close_link(libnet_t *l)
+libnet_close_link(const libnet_t *l)
 {
     if (close(l->fd) == 0)
     {
@@ -726,15 +717,13 @@ int
 libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)   
 {                                                             
     struct strbuf data, ctl;
-    dl_hp_rawdata_req_t *rdata;
-    int c;                     
                           
     if (l == NULL)
     {             
         return (-1);           
     }       
             
-    rdata = (dl_hp_rawdata_req_t *)ctlbuf;
+    dl_hp_rawdata_req_t * const rdata = (dl_hp_rawdata_req_t *)ctlbuf;
     rdata->dl_primitive = DL_HP_RAWDATA_REQ; 
 
     /* send it */                                  
@@ -746,7 +735,7 @@ libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
     data.len    = size;                                
     data.buf    = packet;  
 
-    c = putmsg(l->fd, &ctl, &data, 0);
+    const int c = putmsg(l->fd, &ctl, &data, 0);
     if (c == -1)                      
     {                    
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
@@ -763,7 +752,6 @@ libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
 int
 libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
 {
-    int c;
     struct strbuf data;
 
     if (l == NULL)
@@ -775,7 +763,7 @@ libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
     data.len    = size;
     data.buf    = packet;
 
-    c = putmsg(l->fd, NULL, &data, 0);
+    const int c = putmsg(l->fd, NULL, &data, 0);
     if (c == -1)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
@@ -793,16 +781,12 @@ libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
 struct libnet_ether_addr *
 libnet_get_hwaddr(libnet_t *l)
 {
-    union DL_primitives *dlp;
-    int8_t *buf;
-    int8_t *mac;
-
     if (l == NULL)
     { 
         return (NULL);
     }
 
-    buf = (int8_t *)malloc(2048);
+    int8_t * const buf = (int8_t *)malloc(2048);
     if (buf == NULL)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE, "%s(): malloc(): %s",
@@ -810,7 +794,7 @@ libnet_get_hwaddr(libnet_t *l)
         return (NULL);
     }
 
-    dlp = (union DL_primitives *)buf;
+    union DL_primitives * const dlp = (union DL_primitives *)buf;
 
     dlp->physaddr_req.dl_primitive = DL_PHYS_ADDR_REQ;
     dlp->physaddr_req.dl_addr_type = DL_CURR_PHYS_ADDR;
@@ -828,7 +812,7 @@ libnet_get_hwaddr(libnet_t *l)
         return (NULL);
     }
 
-    mac = (int8_t *)dlp + dlp->physaddr_ack.dl_addr_offset;
+    int8_t * const mac = (int8_t *)dlp + dlp->physaddr_ack.dl_addr_offset;
     memcpy(l->link_addr.ether_addr_octet, mac, ETHER_ADDR_LEN);
     free(buf);
 

--- a/src/libnet_link_linux.c
+++ b/src/libnet_link_linux.c
@@ -167,7 +167,7 @@ bad:
 
 
 int
-libnet_close_link(const libnet_t *l)
+libnet_close_link(libnet_t *l)
 {
     if (close(l->fd) == 0)
     {

--- a/src/libnet_link_linux.c
+++ b/src/libnet_link_linux.c
@@ -68,7 +68,7 @@ int
 libnet_open_link(libnet_t *l)
 {
     struct ifreq ifr;
-    int n = 1;
+    const int n = 1;
 
     if (l == NULL)
     { 
@@ -167,7 +167,7 @@ bad:
 
 
 int
-libnet_close_link(libnet_t *l)
+libnet_close_link(const libnet_t *l)
 {
     if (close(l->fd) == 0)
     {
@@ -201,7 +201,6 @@ get_iface_index(int fd, const char *device)
 int
 libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
 {
-    ssize_t c;
     struct sockaddr_ll sa;
 
     if (l == NULL)
@@ -218,7 +217,7 @@ libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
     }
     sa.sll_protocol  = htons(ETH_P_ALL);
 
-    c = sendto(l->fd, packet, size, 0,
+    const ssize_t c = sendto(l->fd, packet, size, 0,
             (struct sockaddr *)&sa, sizeof (sa));
     if (c != (ssize_t)size)
     {
@@ -233,7 +232,6 @@ libnet_write_link(libnet_t *l, const uint8_t *packet, uint32_t size)
 struct libnet_ether_addr *
 libnet_get_hwaddr(libnet_t *l)
 {
-    int fd;
     struct ifreq ifr;
 
     if (l == NULL)
@@ -254,7 +252,7 @@ libnet_get_hwaddr(libnet_t *l)
     /*
      *  Create dummy socket to perform an ioctl upon.
      */
-    fd = socket(AF_INET, SOCK_DGRAM, 0);
+    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,

--- a/src/libnet_link_nit.c
+++ b/src/libnet_link_nit.c
@@ -43,12 +43,11 @@
 #endif
 
 struct libnet_link_int *
-libnet_open_link_interface(int8_t *device, int8_t *ebuf)
+libnet_open_link_interface(const int8_t *device, int8_t *ebuf)
 {
     struct sockaddr_nit snit;
-    struct libnet_link_int *l;
 
-    l = (struct libnet_link_int *)malloc(sizeof(*p));
+    struct libnet_link_int * const l = (struct libnet_link_int *)malloc(sizeof(*p));
     if (l == NULL)
     {
         strcpy(ebuf, strerror(errno));
@@ -109,16 +108,15 @@ libnet_close_link_interface(struct libnet_link_int *l)
 
 
 int
-write_link_layer(struct libnet_link_int *l, const int8_t *device,
-            uint8_t *buf, int len)
+write_link_layer(const struct libnet_link_int *l, const int8_t *device,
+            const uint8_t *buf, int len)
 {
-    int c;
     struct sockaddr sa;
 
     memset(&sa, 0, sizeof(sa));
     strncpy(sa.sa_data, device, sizeof(sa.sa_data));
 
-    c = sendto(l->fd, buf, len, 0, &sa, sizeof(sa));
+    const int c = sendto(l->fd, buf, len, 0, &sa, sizeof(sa));
     if (c != len)
     {
         /* error */

--- a/src/libnet_link_nit.c
+++ b/src/libnet_link_nit.c
@@ -91,6 +91,7 @@ bad:
 }
 
 
+/* FIXME: The function prototype is different from the one found in the header */
 int
 libnet_close_link_interface(struct libnet_link_int *l)
 {

--- a/src/libnet_link_pf.c
+++ b/src/libnet_link_pf.c
@@ -46,15 +46,14 @@
 #endif
 
 struct libnet_link_int *
-libnet_open_link_interface(int8_t *device, int8_t *ebuf)
+libnet_open_link_interface(const int8_t *device, int8_t *ebuf)
 {
-    struct libnet_link_int *l;
     int16_t enmode;
     int backlog = -1;   /* request the most */
     struct enfilter Filter;
     struct endevp devparams;
 
-    l = (struct libnet_link_int *)malloc(sizeof(*l));
+    struct libnet_link_int * const l = (struct libnet_link_int *)malloc(sizeof(*l));
     if (l == NULL)
     {
         snprintf(ebuf, LIBNET_ERRBUF_SIZE,
@@ -162,9 +161,7 @@ int
 libnet_write_link_layer(struct libnet_link_int *l, const int8_t *device,
             const uint8_t *buf, int len)
 {
-    int c;
-
-    c = write(l->fd, buf, len);
+    const int c = write(l->fd, buf, len);
     if (c != len)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,

--- a/src/libnet_link_pf.c
+++ b/src/libnet_link_pf.c
@@ -141,6 +141,7 @@ bad:
 }
 
 
+/* FIXME: The function prototype is different from the one found in the header */
 int
 libnet_close_link_interface(struct libnet_link_int *l)
 {

--- a/src/libnet_link_snit.c
+++ b/src/libnet_link_snit.c
@@ -51,7 +51,7 @@ libnet_open_link_interface(const int8_t *device, int8_t *ebuf)
 {
     struct strioctl si;	    /* struct for ioctl() */
     struct ifreq ifr;       /* interface request struct */
-    static int8_t dev[] = "/dev/nit";
+    static const int8_t dev[] = "/dev/nit";
 
     struct libnet_link_int * const l = (struct libnet_link_int *)malloc(sizeof(*l));
     if (l == NULL)
@@ -117,6 +117,7 @@ bad:
 }
 
 
+/* FIXME: The function prototype is different from the one found in the header */
 int
 libnet_close_link_interface(struct libnet_link_int *l)
 {

--- a/src/libnet_link_snit.c
+++ b/src/libnet_link_snit.c
@@ -47,14 +47,13 @@
 #endif
 
 struct libnet_link_int *
-libnet_open_link_interface(int8_t *device, int8_t *ebuf)
+libnet_open_link_interface(const int8_t *device, int8_t *ebuf)
 {
     struct strioctl si;	    /* struct for ioctl() */
     struct ifreq ifr;       /* interface request struct */
     static int8_t dev[] = "/dev/nit";
-    struct libnet_link_int *l;
 
-    l = (struct libnet_link_int *)malloc(sizeof(*l));
+    struct libnet_link_int * const l = (struct libnet_link_int *)malloc(sizeof(*l));
     if (l == NULL)
     {
         strcpy(ebuf, strerror(errno));
@@ -138,13 +137,12 @@ int
 libnet_write_link_layer(struct libnet_link_int *l, const int8_t *device,
             const uint8_t *buf, int len)
 {
-    int c;
     struct sockaddr sa;
 
     memset(&sa, 0, sizeof(sa));
     strncpy(sa.sa_data, device, sizeof(sa.sa_data));
 
-    c = sendto(l->fd, buf, len, 0, &sa, sizeof(sa));
+    const int c = sendto(l->fd, buf, len, 0, &sa, sizeof(sa));
     if (c != len)
     {
         /* err */

--- a/src/libnet_link_snoop.c
+++ b/src/libnet_link_snoop.c
@@ -131,7 +131,7 @@ libnet_open_link(libnet_t *l)
 
     return 1;
 bad:
-    // Is this bug? closing uninitialized fd
+    /* FIXME: Is this bug? closing uninitialized fd */
     close(fd);
     free(l);
     return -1;
@@ -139,7 +139,7 @@ bad:
 
 
 int
-libnet_close_link(const libnet_t *l)
+libnet_close_link(libnet_t *l)
 {
     if (close(l->fd) == 0)
     {

--- a/src/libnet_link_snoop.c
+++ b/src/libnet_link_snoop.c
@@ -131,6 +131,7 @@ libnet_open_link(libnet_t *l)
 
     return 1;
 bad:
+    // Is this bug? closing uninitialized fd
     close(fd);
     free(l);
     return -1;
@@ -138,7 +139,7 @@ bad:
 
 
 int
-libnet_close_link(libnet_t *l)
+libnet_close_link(const libnet_t *l)
 {
     if (close(l->fd) == 0)
     {
@@ -156,7 +157,7 @@ libnet_write_link(libnet_t *l, const uint8_t *buf, uint32_t len)
 {
     int c;
     struct ifreq ifr;
-    struct ether_header *eh = (struct ether_header *)buf;
+    struct ether_header * const eh = (struct ether_header *)buf;
 
     memset(&ifr, 0, sizeof(ifr));
     strncpy(ifr.ifr_name, l->device, sizeof(ifr.ifr_name));
@@ -182,9 +183,9 @@ struct libnet_ether_addr *
 libnet_get_hwaddr(libnet_t *l)
 {
     struct ifreq ifdat;
-    int s = -1;
+    const int s = socket(PF_RAW, SOCK_RAW, RAWPROTO_SNOOP);
 
-    if (-1 == (s = socket(PF_RAW, SOCK_RAW, RAWPROTO_SNOOP)))
+    if (s == -1)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                 "socket(): %s", strerror(errno));

--- a/src/libnet_link_win32.c
+++ b/src/libnet_link_win32.c
@@ -188,7 +188,7 @@ libnet_open_link(libnet_t *l)
 }
 
 int
-libnet_close_link_interface(libnet_t *l)
+libnet_close_link_interface(const libnet_t *l)
 {
     if (l->lpAdapter)
     {
@@ -217,9 +217,8 @@ libnet_write_link(libnet_t *l, const uint8_t *data, uint32_t size)
 struct libnet_ether_addr *
 libnet_get_hwaddr(libnet_t *l)
 {
-    struct libnet_ether_addr *mac = &l->link_addr;
-    ULONG IoCtlBufferLength = (sizeof(PACKET_OID_DATA) + sizeof(ULONG) - 1);
-    PPACKET_OID_DATA OidData;
+    struct libnet_ether_addr * const mac = &l->link_addr;
+    const ULONG IoCtlBufferLength = (sizeof(PACKET_OID_DATA) + sizeof(ULONG) - 1);
 
     int i = 0;
 
@@ -238,7 +237,7 @@ libnet_get_hwaddr(libnet_t *l)
         }
     }
 
-    OidData = (struct _PACKET_OID_DATA *)malloc(IoCtlBufferLength);
+    const PPACKET_OID_DATA OidData = (struct _PACKET_OID_DATA *)malloc(IoCtlBufferLength);
     if (OidData == NULL)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
@@ -279,7 +278,6 @@ libnet_win32_get_remote_mac(libnet_t *l, DWORD DestIP)
     ULONG   pulMac[6];
     ULONG   ulLen = 6;
 	static PBYTE pbHexMac;
-	PIP_ADAPTER_INFO pinfo = NULL;
 	DWORD dwSize = 0;
 	struct sockaddr_in sin;
 	static BYTE bcastmac[]= {0xFF,0xFF,0xFF,0xFF,0xFF,0xFF};
@@ -295,7 +293,7 @@ libnet_win32_get_remote_mac(libnet_t *l, DWORD DestIP)
 		{
 			*(int32_t *)&sin.sin_addr = DestIP;
 			GetAdaptersInfo(NULL, &dwSize);
-			pinfo = (PIP_ADAPTER_INFO)GlobalAlloc(GPTR, dwSize);
+			const PIP_ADAPTER_INFO pinfo = (PIP_ADAPTER_INFO)GlobalAlloc(GPTR, dwSize);
 			GetAdaptersInfo(pinfo, &dwSize);
 			if(pinfo != NULL)
 			{
@@ -328,7 +326,7 @@ libnet_win32_get_remote_mac(libnet_t *l, DWORD DestIP)
 BYTE *libnet_win32_read_arp_table(DWORD DestIP)
 {
     static BYTE buffMAC[6];
-    BOOL fOrder = TRUE;
+    const BOOL fOrder = TRUE;
     DWORD status;
 
     MIB_IPNETTABLE *pIpNetTable = NULL;

--- a/src/libnet_link_win32.c
+++ b/src/libnet_link_win32.c
@@ -188,7 +188,7 @@ libnet_open_link(libnet_t *l)
 }
 
 int
-libnet_close_link_interface(const libnet_t *l)
+libnet_close_link_interface(libnet_t *l)
 {
     if (l->lpAdapter)
     {

--- a/src/libnet_pblock.c
+++ b/src/libnet_pblock.c
@@ -96,7 +96,7 @@ libnet_pblock_probe(libnet_t *l, libnet_ptag_t ptag, uint32_t b_len, uint8_t typ
 
 static void* zmalloc(libnet_t* l, uint32_t size, const char* func)
 {
-    void* const v = malloc(size);
+    void * const v = malloc(size);
     if(v)
         memset(v, 0, size);
     else
@@ -304,7 +304,7 @@ static int pblock_is_ip(const libnet_pblock_t* p)
 static int calculate_ip_offset(const libnet_t* l, const libnet_pblock_t* q)
 {
     int ip_offset = 0;
-    const libnet_pblock_t* p = l->protocol_blocks;
+    const libnet_pblock_t * p = l->protocol_blocks;
     for(; p && p != q; p = p->next) {
 	ip_offset += p->b_len;
     }

--- a/src/libnet_pblock.c
+++ b/src/libnet_pblock.c
@@ -37,7 +37,6 @@ libnet_pblock_t *
 libnet_pblock_probe(libnet_t *l, libnet_ptag_t ptag, uint32_t b_len, uint8_t type)
 {
     int offset;
-    libnet_pblock_t *p;
 
     if (ptag == LIBNET_PTAG_INITIALIZER)
     {
@@ -48,7 +47,7 @@ libnet_pblock_probe(libnet_t *l, libnet_ptag_t ptag, uint32_t b_len, uint8_t typ
      *  Update this pblock, don't create a new one.  Note that if the
      *  new packet size is larger than the old one we will do a malloc.
      */
-    p = libnet_pblock_find(l, ptag);
+    libnet_pblock_t * const p = libnet_pblock_find(l, ptag);
 
     if (p == NULL)
     {
@@ -97,7 +96,7 @@ libnet_pblock_probe(libnet_t *l, libnet_ptag_t ptag, uint32_t b_len, uint8_t typ
 
 static void* zmalloc(libnet_t* l, uint32_t size, const char* func)
 {
-    void* v = malloc(size);
+    void* const v = malloc(size);
     if(v)
         memset(v, 0, size);
     else
@@ -109,7 +108,7 @@ static void* zmalloc(libnet_t* l, uint32_t size, const char* func)
 libnet_pblock_t *
 libnet_pblock_new(libnet_t *l, uint32_t b_len)
 {
-    libnet_pblock_t *p = zmalloc(l, sizeof(libnet_pblock_t), __func__);
+    libnet_pblock_t * const p = zmalloc(l, sizeof(libnet_pblock_t), __func__);
     if(!p)
         return NULL;
 
@@ -145,10 +144,8 @@ libnet_pblock_new(libnet_t *l, uint32_t b_len)
 int
 libnet_pblock_swap(libnet_t *l, libnet_ptag_t ptag1, libnet_ptag_t ptag2)
 {
-    libnet_pblock_t *p1, *p2;
-
-    p1 = libnet_pblock_find(l, ptag1);
-    p2 = libnet_pblock_find(l, ptag2);
+    libnet_pblock_t * const p1 = libnet_pblock_find(l, ptag1);
+    libnet_pblock_t * const p2 = libnet_pblock_find(l, ptag2);
     if (p1 == NULL || p2 == NULL)
     {
         /* error set elsewhere */
@@ -207,10 +204,8 @@ int
 libnet_pblock_insert_before(libnet_t *l, libnet_ptag_t ptag1,
         libnet_ptag_t ptag2)
 {
-    libnet_pblock_t *p1, *p2;
-
-    p1 = libnet_pblock_find(l, ptag1);
-    p2 = libnet_pblock_find(l, ptag2);
+    libnet_pblock_t * const p1 = libnet_pblock_find(l, ptag1);
+    libnet_pblock_t * const p2 = libnet_pblock_find(l, ptag2);
     if (p1 == NULL || p2 == NULL)
     {
         /* error set elsewhere */
@@ -297,7 +292,7 @@ libnet_pblock_update(libnet_t *l, libnet_pblock_t *p, uint32_t h_len, uint8_t ty
     return (p->ptag);
 }
 
-static int pblock_is_ip(libnet_pblock_t* p)
+static int pblock_is_ip(const libnet_pblock_t* p)
 {
     return p->type == LIBNET_PBLOCK_IPV4_H || p->type == LIBNET_PBLOCK_IPV6_H;
 }
@@ -306,10 +301,10 @@ static int pblock_is_ip(libnet_pblock_t* p)
  * from end of packet. if there is no offset, we'll return the total size,
  * and things will break later
  */
-static int calculate_ip_offset(libnet_t* l, libnet_pblock_t* q)
+static int calculate_ip_offset(const libnet_t* l, const libnet_pblock_t* q)
 {
     int ip_offset = 0;
-    libnet_pblock_t* p = l->protocol_blocks;
+    const libnet_pblock_t* p = l->protocol_blocks;
     for(; p && p != q; p = p->next) {
 	ip_offset += p->b_len;
     }
@@ -347,7 +342,7 @@ libnet_pblock_coalesce(libnet_t *l, uint8_t **packet, uint32_t *size)
     if(!l->total_size && !l->aligner) {
         /* Avoid allocating zero bytes of memory, it perturbs electric fence. */
         *packet = malloc(1);
-        **packet =1;
+        **packet = 1;
     } else {
         *packet = malloc(l->aligner + l->total_size);
     }

--- a/src/libnet_port_list.c
+++ b/src/libnet_port_list.c
@@ -37,12 +37,11 @@ uint16_t *all_lists;
 int
 libnet_plist_chain_new(libnet_t *l, libnet_plist_t **plist, char *token_list)
 {
-    char libnet_plist_legal_tokens[] = "0123456789,- ";
+    const char libnet_plist_legal_tokens[] = "0123456789,- ";
     libnet_plist_t *tmp;
     char *tok;
     int i, valid_token, cur_node;
     size_t j;
-    uint16_t *all_lists_tmp;
     static uint8_t cur_id;
 
     if (l == NULL)
@@ -94,7 +93,7 @@ libnet_plist_chain_new(libnet_t *l, libnet_plist_t **plist, char *token_list)
     tmp->node = cur_node = 0;
     tmp->next = NULL;
     tmp->id = cur_id;
-    all_lists_tmp = all_lists;
+    uint16_t * const all_lists_tmp = all_lists;
     all_lists = realloc(all_lists_tmp, (sizeof(uint16_t) * (cur_id + 1)));
     if (!all_lists)
     {
@@ -186,14 +185,13 @@ int
 libnet_plist_chain_next_pair(libnet_plist_t *plist, uint16_t *bport,
         uint16_t *eport)
 {
-    uint16_t *node_cnt;
     uint16_t tmp_cnt;
 
     if (plist == NULL)
     {
         return (-1);
     }
-    node_cnt = &(all_lists[plist->id]);
+    uint16_t * const node_cnt = &(all_lists[plist->id]);
 
     /*
      *  We are at the end of the list.
@@ -271,7 +269,6 @@ int
 libnet_plist_chain_free(libnet_plist_t *plist)
 {
     uint16_t i;
-    libnet_plist_t *tmp;
 
     if (plist == NULL)
     {
@@ -280,7 +277,7 @@ libnet_plist_chain_free(libnet_plist_t *plist)
 
     for (i = plist->node; i; i--)
     {
-        tmp = plist;
+        libnet_plist_t * const tmp = plist;
         plist = plist->next;
         free(tmp);
     }

--- a/src/libnet_port_list.c
+++ b/src/libnet_port_list.c
@@ -269,6 +269,7 @@ int
 libnet_plist_chain_free(libnet_plist_t *plist)
 {
     uint16_t i;
+    libnet_plist_t *tmp;
 
     if (plist == NULL)
     {
@@ -277,7 +278,7 @@ libnet_plist_chain_free(libnet_plist_t *plist)
 
     for (i = plist->node; i; i--)
     {
-        libnet_plist_t * const tmp = plist;
+        tmp = plist;
         plist = plist->next;
         free(tmp);
     }

--- a/src/libnet_raw.c
+++ b/src/libnet_raw.c
@@ -53,13 +53,13 @@ libnet_open_raw6(libnet_t *l)
 }
 
 int
-libnet_close_raw4(libnet_t *l)
+libnet_close_raw4(const libnet_t *l)
 {
     return (libnet_close_link_interface(l));
 }
 
 int
-libnet_close_raw6(libnet_t *l)
+libnet_close_raw6(const libnet_t *l)
 {
     return (libnet_close_link_interface(l));
 }
@@ -68,14 +68,14 @@ libnet_close_raw6(libnet_t *l)
 static int libnet_finish_setup_socket(libnet_t *l)
 {
 #if !(__WIN32__)
-     int n = 1;
+     const int n = 1;
 #if (__svr4__)
-     void *nptr = &n;
+     const void * const nptr = &n;
 #else
-    int *nptr = &n;
+    const int * const nptr = &n;
 #endif  /* __svr4__ */
 #else
-	BOOL n;
+	const BOOL n;
 #endif
     unsigned len;
 
@@ -116,14 +116,14 @@ int
 libnet_open_raw4(libnet_t *l)
 {
 #if !(__WIN32__)
-     int n = 1;
+     const int n = 1;
 #if (__svr4__)
-     void *nptr = &n;
+     const void * const nptr = &n;
 #else
-    int *nptr = &n;
+    const int * const nptr = &n;
 #endif  /* __svr4__ */
 #else
-	BOOL n;
+	const BOOL n;
 #endif
 
     if (l == NULL)
@@ -176,7 +176,7 @@ bad:
 
 
 int
-libnet_close_raw4(libnet_t *l)
+libnet_close_raw4(const libnet_t *l)
 {
     if (l == NULL)
     { 
@@ -222,7 +222,7 @@ bad:
 #endif
 
 int
-libnet_close_raw6(libnet_t *l)
+libnet_close_raw6(const libnet_t *l)
 {
     if (l == NULL)
     { 

--- a/src/libnet_raw.c
+++ b/src/libnet_raw.c
@@ -53,13 +53,13 @@ libnet_open_raw6(libnet_t *l)
 }
 
 int
-libnet_close_raw4(const libnet_t *l)
+libnet_close_raw4(libnet_t *l)
 {
     return (libnet_close_link_interface(l));
 }
 
 int
-libnet_close_raw6(const libnet_t *l)
+libnet_close_raw6(libnet_t *l)
 {
     return (libnet_close_link_interface(l));
 }
@@ -176,7 +176,7 @@ bad:
 
 
 int
-libnet_close_raw4(const libnet_t *l)
+libnet_close_raw4(libnet_t *l)
 {
     if (l == NULL)
     { 
@@ -222,7 +222,7 @@ bad:
 #endif
 
 int
-libnet_close_raw6(const libnet_t *l)
+libnet_close_raw6(libnet_t *l)
 {
     if (l == NULL)
     { 

--- a/src/libnet_resolve.c
+++ b/src/libnet_resolve.c
@@ -422,6 +422,7 @@ uint8_t *
 libnet_hex_aton(const char *s, int *len)
 {
     int i;
+    int32_t l;
     char *pp;
         
     while (isspace(*s))
@@ -443,7 +444,7 @@ libnet_hex_aton(const char *s, int *len)
     /* expect len hex octets separated by ':' */
     for (i = 0; i < *len + 1; i++)
     {
-        const int32_t l = strtol(s, &pp, 16);
+        l = strtol(s, &pp, 16);
         if (pp == s || l > 0xff || l < 0)
         {
             *len = 0;

--- a/src/libnet_resolve.c
+++ b/src/libnet_resolve.c
@@ -44,7 +44,6 @@ libnet_addr2name4(uint32_t in, uint8_t use_name)
 	#define HOSTNAME_SIZE 512
     static char hostname[HOSTNAME_SIZE+1], hostname2[HOSTNAME_SIZE+1];
     static uint16_t which;
-    uint8_t *p;
 
     struct hostent *host_ent = NULL;
     struct in_addr addr;
@@ -67,7 +66,7 @@ libnet_addr2name4(uint32_t in, uint8_t use_name)
     if (!host_ent)
     {
 
-        p = (uint8_t *)&in;
+        uint8_t * const p = (uint8_t *)&in;
    		snprintf(((which % 2) ? hostname : hostname2), HOSTNAME_SIZE,
                  "%d.%d.%d.%d",
                  (p[0] & 255), (p[1] & 255), (p[2] & 255), (p[3] & 255));
@@ -86,7 +85,6 @@ void
 libnet_addr2name4_r(uint32_t in, uint8_t use_name, char *hostname,
         int hostname_len)
 {
-    uint8_t *p;
     struct hostent *host_ent = NULL;
     struct in_addr addr;
 
@@ -98,7 +96,7 @@ libnet_addr2name4_r(uint32_t in, uint8_t use_name, char *hostname,
     }
     if (!host_ent)
     {
-        p = (uint8_t *)&in;
+        uint8_t * const p = (uint8_t *)&in;
         snprintf(hostname, hostname_len, "%d.%d.%d.%d",
                 (p[0] & 255), (p[1] & 255), (p[2] & 255), (p[3] & 255));
     }
@@ -113,7 +111,6 @@ uint32_t
 libnet_name2addr4(libnet_t *l, const char *host_name, uint8_t use_name)
 {
     struct in_addr addr;
-    struct hostent *host_ent; 
     uint32_t m;
     uint32_t val;
     int i;
@@ -122,7 +119,8 @@ libnet_name2addr4(libnet_t *l, const char *host_name, uint8_t use_name)
     {
         if ((addr.s_addr = inet_addr(host_name)) == INADDR_NONE)
         {
-            if (!(host_ent = gethostbyname(host_name)))
+            struct hostent * const host_ent = gethostbyname(host_name);
+            if (!host_ent)
             {
                 snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
                         "%s(): %s", __func__,
@@ -359,8 +357,6 @@ uint32_t
 libnet_get_ipaddr4(libnet_t *l)
 {
     struct ifreq ifr;
-    struct sockaddr_in *sin;
-    int fd;
 
     if (l == NULL)
     {
@@ -368,7 +364,7 @@ libnet_get_ipaddr4(libnet_t *l)
     }
 
     /* create dummy socket to perform an ioctl upon */
-    fd = socket(PF_INET, SOCK_DGRAM, 0);
+    const int fd = socket(PF_INET, SOCK_DGRAM, 0);
     if (fd == -1)
     {
         snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
@@ -376,7 +372,7 @@ libnet_get_ipaddr4(libnet_t *l)
         return (-1);
     }
 
-    sin = (struct sockaddr_in *)&ifr.ifr_addr;
+    struct sockaddr_in * const sin = (struct sockaddr_in *)&ifr.ifr_addr;
 
     if (l->device == NULL)
     {
@@ -425,9 +421,7 @@ libnet_get_ipaddr4(libnet_t *l)
 uint8_t *
 libnet_hex_aton(const char *s, int *len)
 {
-    uint8_t *buf;
     int i;
-    int32_t l;
     char *pp;
         
     while (isspace(*s))
@@ -441,7 +435,7 @@ libnet_hex_aton(const char *s, int *len)
             (*len)++;
         }
     }
-    buf = malloc(*len + 1);
+    uint8_t * const buf = malloc(*len + 1);
     if (buf == NULL)
     {
         return (NULL);
@@ -449,7 +443,7 @@ libnet_hex_aton(const char *s, int *len)
     /* expect len hex octets separated by ':' */
     for (i = 0; i < *len + 1; i++)
     {
-        l = strtol(s, &pp, 16);
+        const int32_t l = strtol(s, &pp, 16);
         if (pp == s || l > 0xff || l < 0)
         {
             *len = 0;


### PR DESCRIPTION
This PR will add `const` wherever possible and make sense.

Changes
- Add `const` for function parameters passed by reference where the function does not modify (or free) the data pointed to
- Remove `const` in a function prototype for a parameter passed by value
- Add `const` on local variables

Detailed discussion can be found here https://github.com/libnet/libnet/issues/164

Ready for review from maintainer @troglobit 